### PR TITLE
Adds Dropwizard example

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -11,7 +11,7 @@ jobs:
   build-on-linux:
     strategy:
       matrix:
-        project: [armeria, webmvc25-jetty, webmvc3-jetty, webmvc4-boot, webmvc4-jetty]
+        project: [armeria, dropwizard, webmvc25-jetty, webmvc3-jetty, webmvc4-boot, webmvc4-jetty]
     runs-on: ubuntu-latest
     name: Build and verify Docker images
     steps:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Here are the example projects you can try:
   * Trace Instrumentation: [Armeria](https://armeria.dev/), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
   * Trace Configuration: [Brave API](https://github.com/openzipkin/brave/tree/master/brave#setup) [Java](armeria/src/main/java/brave/example/HttpTracingFactory.java)
 
+* [dropwizard](dropwizard) `PROJECT=webmvc4-boot docker-compose up`
+  * Runtime: JaxRS 2, Jersey 2.31, Apache HttpClient 4.5, Jetty 9.4, SLF4J 1.7, JRE 15
+  * Trace Instrumentation: [Jersey Server](https://github.com/openzipkin/brave/tree/master/instrumentation/jersey-server), [JaxRS 2](https://github.com/openzipkin/brave/tree/master/instrumentation/jaxrs2), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
+  * Trace Configuration: [Dropwizard Zipkin](https://github.com/smoketurner/dropwizard-zipkin) [Java](dropwizard/src/main/java/brave/example/ExampleApplication.java) [Yaml](dropwizard/src/main/resources/server.yml)
+
 * [webmvc25-jetty](webmvc25-jetty) `PROJECT=webmvc25-jetty docker-compose up`
   * Runtime: Spring 2.5, Apache HttpClient 4.3, Servlet 2.5, Jetty 7.6, Log4J 1.2, JRE 6
   * Trace Instrumentation: [Servlet](https://github.com/openzipkin/brave/tree/master/instrumentation/servlet), [Spring MVC](https://github.com/openzipkin/brave/tree/master/instrumentation/spring-webmvc), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [Log4J 1.2](https://github.com/openzipkin/brave/tree/master/context/log4j12)

--- a/docker/bin/install-example
+++ b/docker/bin/install-example
@@ -4,7 +4,7 @@ PROJECT=$1
 
 # Determine the platform explicitly or via convention
 case ${PROJECT} in
-  armeria) PLATFORM=java;;
+  armeria|dropwizard) PLATFORM=java;;
   *) PLATFORM=$(echo "${PROJECT}"|cut -d- -f2);;
 esac
 

--- a/dropwizard/README.md
+++ b/dropwizard/README.md
@@ -1,0 +1,6 @@
+## Tracing Example: Dropwizard
+
+Instead of servlet, this uses [Dropwizard](https://www.dropwizard.io) to serve HTTP
+requests. Both services run as a normal Java application.
+
+* brave.example.FrontendResource and BackendResource : JaxRS controllers

--- a/dropwizard/pom.xml
+++ b/dropwizard/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave.example</groupId>
+    <artifactId>brave-example-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brave-example-dropwizard</artifactId>
+  <packaging>jar</packaging>
+
+  <name>brave-example-dropwizard</name>
+  <description>Tracing Example: Dropwizard/ Java 15</description>
+
+  <properties>
+    <jre.version>15</jre.version>
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- You don't have to add a dependency on Dropwizard because dropwizard-zipkin manages it -->
+    <dropwizard-zipkin.version>2.0.12-1</dropwizard-zipkin.version>
+  </properties>
+
+  <dependencies>
+    <!-- Instruments the underlying Dropwizard requests -->
+    <dependency>
+      <groupId>com.smoketurner.dropwizard</groupId>
+      <artifactId>zipkin-core</artifactId>
+      <version>${dropwizard-zipkin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.smoketurner.dropwizard</groupId>
+      <artifactId>zipkin-client</artifactId>
+      <version>${dropwizard-zipkin.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/dropwizard/src/main/java/brave/example/Backend.java
+++ b/dropwizard/src/main/java/brave/example/Backend.java
@@ -1,0 +1,42 @@
+package brave.example;
+
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
+import io.dropwizard.setup.Environment;
+import java.util.Date;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+/** Example conventions include a self-contained main class. */
+public class Backend extends ExampleApplication<BackendConfiguration> {
+
+  @Path("/")
+  public static class Resource {
+    @GET
+    @Path("/api")
+    public String printDate(@HeaderParam("user_name") String username) {
+      if (username != null) {
+        return new Date().toString() + " " + username;
+      }
+      return new Date().toString();
+    }
+  }
+
+  Backend() {
+    super("backend", 9000);
+  }
+
+  @Override public void run(BackendConfiguration configuration, Environment environment) {
+    super.run(configuration, environment);
+    environment.jersey().register(new Resource());
+  }
+
+  @Override ZipkinFactory zipkinFactory(BackendConfiguration configuration) {
+    return configuration.getZipkin();
+  }
+
+  public static void main(String[] args) throws Exception {
+    new Backend().run();
+  }
+}
+

--- a/dropwizard/src/main/java/brave/example/BackendConfiguration.java
+++ b/dropwizard/src/main/java/brave/example/BackendConfiguration.java
@@ -1,0 +1,14 @@
+package brave.example;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.smoketurner.dropwizard.zipkin.HttpZipkinFactory;
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
+import io.dropwizard.Configuration;
+
+public class BackendConfiguration extends Configuration {
+  final ZipkinFactory zipkin = new HttpZipkinFactory();
+
+  @JsonProperty public ZipkinFactory getZipkin() {
+    return zipkin;
+  }
+}

--- a/dropwizard/src/main/java/brave/example/ExampleApplication.java
+++ b/dropwizard/src/main/java/brave/example/ExampleApplication.java
@@ -1,0 +1,67 @@
+package brave.example;
+
+import com.smoketurner.dropwizard.zipkin.ZipkinBundle;
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/** Helper to bootstrap {@link ZipkinBundle} and reduce replication in example setup. */
+abstract class ExampleApplication<C extends Configuration> extends Application<C> {
+  /** Fake /health endpoint that allows us to ensure our HEALTHCHECK doesn't start traces. */
+  @Path("/")
+  public static class HealthCheck {
+    @GET
+    @Path("/health")
+    public String health() {
+      return "ok";
+    }
+  }
+
+  final String name;
+  ZipkinBundle<C> zipkinBundle;
+
+  ExampleApplication(String name, int port) {
+    this.name = name;
+    System.setProperty("dw.server.applicationConnectors[0].port", String.valueOf(port));
+
+    // Copy properties to zipkin config until we learn how to do the following in example.yaml:
+    //
+    // zipkin:
+    //  serviceName: ${environment.name}
+    //  servicePort: ${dw.server.applicationConnectors[0].port}
+    System.setProperty("dw.zipkin.serviceName", name);
+    System.setProperty("dw.zipkin.servicePort", String.valueOf(port));
+  }
+
+  @Override public final String getName() {
+    return name;
+  }
+
+  @Override public void run(C configuration, Environment environment) {
+    // Our example is single port per app. Also, it is easiest when all health URLs are the same
+    // HTTP path (/health). As these aren't configurable, add our own /health directly
+    environment.jersey().register(new HealthCheck());
+  }
+
+  /** Centralized config for both applications go into one yaml file. */
+  void run() throws Exception {
+    run("server", "example.yml");
+  }
+
+  abstract ZipkinFactory zipkinFactory(C configuration);
+
+  @Override public final void initialize(Bootstrap<C> bootstrap) {
+    bootstrap.setConfigurationSourceProvider(new ResourceConfigurationSourceProvider());
+    zipkinBundle = new ZipkinBundle<C>(getName()) {
+      @Override public ZipkinFactory getZipkinFactory(C configuration) {
+        return zipkinFactory(configuration);
+      }
+    };
+    bootstrap.addBundle(zipkinBundle);
+  }
+}

--- a/dropwizard/src/main/java/brave/example/Frontend.java
+++ b/dropwizard/src/main/java/brave/example/Frontend.java
@@ -1,0 +1,51 @@
+package brave.example;
+
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
+import com.smoketurner.dropwizard.zipkin.client.ZipkinClientBuilder;
+import io.dropwizard.setup.Environment;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+/** Example conventions include a self-contained main class. */
+public class Frontend extends ExampleApplication<FrontendConfiguration> {
+  @Path("/")
+  public static class Resource {
+    final Client client;
+    final String backendEndpoint;
+
+    Resource(Client client, String backendEndpoint) {
+      this.client = client;
+      this.backendEndpoint = backendEndpoint;
+    }
+
+    @GET
+    @Path("/") public Response callBackend() {
+      return client.target(backendEndpoint).request().get();
+    }
+  }
+
+  Frontend() {
+    super("frontend", 8081);
+  }
+
+  @Override public void run(FrontendConfiguration configuration, Environment environment) {
+    super.run(configuration, environment);
+
+    Client client = new ZipkinClientBuilder(environment, zipkinBundle.getHttpTracing().get())
+        .build(configuration.getBackend());
+
+    Resource resource = new Resource(client, configuration.getBackend().getEndpoint());
+
+    environment.jersey().register(resource);
+  }
+
+  @Override ZipkinFactory zipkinFactory(FrontendConfiguration configuration) {
+    return configuration.getZipkin();
+  }
+
+  public static void main(String[] args) throws Exception {
+    new Frontend().run();
+  }
+}

--- a/dropwizard/src/main/java/brave/example/FrontendConfiguration.java
+++ b/dropwizard/src/main/java/brave/example/FrontendConfiguration.java
@@ -1,0 +1,37 @@
+package brave.example;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.smoketurner.dropwizard.zipkin.HttpZipkinFactory;
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
+import com.smoketurner.dropwizard.zipkin.client.ZipkinClientConfiguration;
+import io.dropwizard.Configuration;
+import javax.validation.constraints.NotNull;
+
+public class FrontendConfiguration extends Configuration {
+  static class BackendConfiguration extends ZipkinClientConfiguration {
+    @NotNull String endpoint = "http://127.0.0.1:9000/api";
+
+    BackendConfiguration() {
+      setServiceName("backend");
+    }
+
+    @JsonProperty public String getEndpoint() {
+      return endpoint;
+    }
+
+    @JsonProperty public void setEndpoint(String endpoint) {
+      this.endpoint = endpoint;
+    }
+  }
+
+  final ZipkinFactory zipkin = new HttpZipkinFactory();
+  final BackendConfiguration backend = new BackendConfiguration();
+
+  @JsonProperty public ZipkinFactory getZipkin() {
+    return zipkin;
+  }
+
+  @JsonProperty public BackendConfiguration getBackend() {
+    return backend;
+  }
+}

--- a/dropwizard/src/main/resources/example.yml
+++ b/dropwizard/src/main/resources/example.yml
@@ -1,0 +1,22 @@
+# We have to set a default in yaml in order to override with system properties
+server:
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors: []
+
+zipkin:
+  collector: http
+  baseUrl: http://127.0.0.1:9411/
+  serviceName: ${environment.name}
+  servicePort: ${dw.server.applicationConnectors[0].port}
+
+logging:
+  level: INFO
+  appenders:
+    - type: console
+      timeZone: UTC
+      # Adds trace IDs into the log format
+      logFormat: "%-5p [%d{ISO8601,UTC}] [%X{userName}] [%X{traceId}/%X{spanId}] %c: %m%n%rEx"
+      target: stdout
+


### PR DESCRIPTION
This is the first example to not use Brave configuration directly.

This uses https://github.com/smoketurner/dropwizard-zipkin to manage
tracer configuration.

Similar to the Spring Boot example, this makes a single file for both
examples: `brave.example.Frontend` and `brave.example.Backend` even if
it is more common in practice to split up things into many files.

This helps make the examples easier to maintain at the cost of being
slightly less idiomatic.

cc @jplock as this should eventually be linked to the dropwizard-zipkin
repository. Note this also makes a docker image!