### PR TITLE
Adds details about minimum docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Format version 2.1 was introduced with Docker Compose v1.9
-# We need Docker Compose v1.9 for unset variable interpolation
+# We need Docker Compose v1.9+ for unset variable interpolation
 version: "2.1"
 
 services:
@@ -28,4 +28,3 @@ services:
     container_name: zipkin
     ports:
       - 9411:9411
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Format version 2.1 was introduced with Docker Compose v1.9
+# We need Docker Compose v1.9 for unset variable interpolation
+version: "2.1"
+
 services:
   # Generate traffic by hitting http://localhost:8081
   frontend:


### PR DESCRIPTION
This helps remove a problem when versions aren't quite right noticed by @jorgheymans 

```
~/src/brave-example$ PROJECT=armeria docker-compose up
ERROR: Invalid interpolation format for "frontend" option in service "services": "openzipkin/example-brave:${PROJECT:-armeria}"
```

https://docs.docker.com/compose/release-notes/#1190