### PR TITLE
Adds Ratpack example

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -11,7 +11,7 @@ jobs:
   build-on-linux:
     strategy:
       matrix:
-        project: [armeria, dropwizard, webmvc25-jetty, webmvc3-jetty, webmvc4-boot, webmvc4-jetty]
+        project: [armeria, dropwizard, ratpack, webmvc25-jetty, webmvc3-jetty, webmvc4-boot, webmvc4-jetty]
     runs-on: ubuntu-latest
     name: Build and verify Docker images
     steps:
@@ -19,7 +19,6 @@ jobs:
         uses: docker-practice/actions-setup-docker@master
         with:
           docker_version: 19.03
-          docker_buildx: true
       - name: Cache docker
         uses: actions/cache@v1
         with:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here are the example projects you can try:
   * Trace Configuration: [Dropwizard Zipkin](https://github.com/smoketurner/dropwizard-zipkin) [Java](dropwizard/src/main/java/brave/example/ExampleApplication.java) [Yaml](dropwizard/src/main/resources/server.yml)
 
 * [ratpack](ratpack) `PROJECT=ratpack docker-compose up`
-  * Runtime: Ratpack, Guice, SLF4J 1.7, JRE 15
+  * Runtime: Ratpack 1.8, Guice 4, SLF4J 1.7, JRE 15
   * Trace Instrumentation: [Brave Ratpack](https://github.com/openzipkin-contrib/brave-ratpack)
   * Trace Configuration: [Brave Ratpack Guice](https://github.com/openzipkin-contrib/brave-ratpack) [Java](ratpack/src/main/java/brave/example/Backend.java)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Here are the example projects you can try:
   * Trace Instrumentation: [Jersey Server](https://github.com/openzipkin/brave/tree/master/instrumentation/jersey-server), [JaxRS 2](https://github.com/openzipkin/brave/tree/master/instrumentation/jaxrs2), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
   * Trace Configuration: [Dropwizard Zipkin](https://github.com/smoketurner/dropwizard-zipkin) [Java](dropwizard/src/main/java/brave/example/ExampleApplication.java) [Yaml](dropwizard/src/main/resources/server.yml)
 
+* [ratpack](ratpack) `PROJECT=ratpack docker-compose up`
+  * Runtime: Ratpack, Guice, SLF4J 1.7, JRE 15
+  * Trace Instrumentation: [Brave Ratpack](https://github.com/openzipkin-contrib/brave-ratpack)
+  * Trace Configuration: [Brave Ratpack Guice](https://github.com/openzipkin-contrib/brave-ratpack) [Java](ratpack/src/main/java/brave/example/Backend.java)
+
 * [webmvc25-jetty](webmvc25-jetty) `PROJECT=webmvc25-jetty docker-compose up`
   * Runtime: Spring 2.5, Apache HttpClient 4.3, Servlet 2.5, Jetty 7.6, Log4J 1.2, JRE 6
   * Trace Instrumentation: [Servlet](https://github.com/openzipkin/brave/tree/master/instrumentation/servlet), [Spring MVC](https://github.com/openzipkin/brave/tree/master/instrumentation/spring-webmvc), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [Log4J 1.2](https://github.com/openzipkin/brave/tree/master/context/log4j12)

--- a/docker/bin/install-example
+++ b/docker/bin/install-example
@@ -1,10 +1,10 @@
 #!/bin/sh
-set -eu
+set -eux
 PROJECT=$1
 
 # Determine the platform explicitly or via convention
 case ${PROJECT} in
-  armeria|dropwizard) PLATFORM=java;;
+  armeria|dropwizard|ratpack) PLATFORM=java;;
   *) PLATFORM=$(echo "${PROJECT}"|cut -d- -f2);;
 esac
 
@@ -21,5 +21,12 @@ mv install /install
 # Add scripts used at runtime
 cd /install/bin
 cp -p /code/docker/bin/start-example-header start-brave-example
+if [ "${PROJECT}" = "ratpack" ]
+then
+  cat >> start-brave-example <<-'EOF'
+# Add property prefix "ratpack."
+EXAMPLE_OPTS=$(echo ${EXAMPLE_OPTS} |sed "s/-D/-Dratpack./g")
+EOF
+fi
 cat /code/docker/bin/start-${PLATFORM}-example >> start-brave-example
 cp -p /code/docker/bin/docker-healthcheck .

--- a/ratpack/README.md
+++ b/ratpack/README.md
@@ -1,0 +1,7 @@
+## Tracing Example: Ratpack
+
+Instead of servlet, this uses [Ratpack](https://ratpack.io/) to serve HTTP
+requests. Both services run as a normal Java application.
+
+*   brave.example.Frontend and Backend : Main classes that define Ratpack HTTP handlers
+*   brave.example.ZipkinConfig : config properties that can be overridden via ratpack.zipkin.X

--- a/ratpack/pom.xml
+++ b/ratpack/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave.example</groupId>
+    <artifactId>brave-example-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brave-example-ratpack</artifactId>
+  <packaging>jar</packaging>
+
+  <name>brave-example-ratpack</name>
+  <description>Tracing Example: Ratpack/ Java 15</description>
+
+  <properties>
+    <jre.version>15</jre.version>
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <ratpack.version>1.8.0</ratpack.version>
+    <brave-ratpack.version>2.6.3</brave-ratpack.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.ratpack</groupId>
+      <artifactId>ratpack-guice</artifactId>
+      <version>${ratpack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+
+    <!-- Instruments the underlying Ratpack requests -->
+    <dependency>
+      <groupId>io.zipkin.brave.ratpack</groupId>
+      <artifactId>brave-ratpack</artifactId>
+      <version>${brave-ratpack.version}</version>
+    </dependency>
+
+    <!-- The below is needed to report traces to http://127.0.0.1:9411/api/v2/spans -->
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-urlconnection</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/ratpack/src/main/java/brave/example/Backend.java
+++ b/ratpack/src/main/java/brave/example/Backend.java
@@ -1,0 +1,40 @@
+package brave.example;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import ratpack.guice.Guice;
+import ratpack.handling.Context;
+import ratpack.server.RatpackServer;
+import ratpack.server.ServerConfig;
+import ratpack.zipkin.ServerTracingModule;
+
+public final class Backend {
+
+  String printDate(Context ctx) {
+    String response = new Date().toString();
+    Optional<String> username = ctx.header("user_name");
+    if (username.isPresent()) response += " " + username.get();
+    return response;
+  }
+
+  public static void main(String[] args) throws Exception {
+    ServerConfig serverConfig = ServerConfig.embedded()
+        .props(Collections.singletonMap("zipkin.service", "backend"))
+        .sysProps() // allows overrides like ratpack.zipkin.baseUrl=...
+        .port(9000)
+        .build();
+
+    RatpackServer.start(server -> server.serverConfig(serverConfig)
+        .registry(Guice.registry(bindings -> bindings
+            .moduleConfig(ServerTracingModule.class,
+                serverConfig.get("/zipkin", ZipkinConfig.class).toModuleConfig())
+            .bind(Backend.class)
+        ))
+        .handlers(chain -> chain
+            .get("health", ctx -> ctx.render("ok"))
+            .get("api", ctx -> ctx.render(ctx.get(Backend.class).printDate(ctx)))
+        )
+    );
+  }
+}

--- a/ratpack/src/main/java/brave/example/Frontend.java
+++ b/ratpack/src/main/java/brave/example/Frontend.java
@@ -1,0 +1,53 @@
+package brave.example;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.name.Names;
+import java.net.URI;
+import javax.inject.Inject;
+import javax.inject.Named;
+import ratpack.exec.Promise;
+import ratpack.guice.Guice;
+import ratpack.http.client.HttpClient;
+import ratpack.server.RatpackServer;
+import ratpack.server.ServerConfig;
+import ratpack.zipkin.ServerTracingModule;
+import ratpack.zipkin.Zipkin;
+
+public final class Frontend {
+  final HttpClient client;
+  final URI backendEndpoint;
+
+  @Inject Frontend(@Zipkin HttpClient client, @Named("backendEndpoint") String backendEndpoint) {
+    this.client = client;
+    this.backendEndpoint = URI.create(backendEndpoint);
+  }
+
+  Promise<String> callBackend() {
+    return client.get(backendEndpoint).map(response -> response.getBody().getText());
+  }
+
+  public static void main(String[] args) throws Exception {
+    ServerConfig serverConfig = ServerConfig.embedded()
+        .props(ImmutableMap.of(
+            "zipkin.service", "frontend",
+            "backend.endpoint", "http://127.0.0.1:9000/api"))
+        .sysProps() // allows overrides like ratpack.zipkin.baseUrl=...
+        .port(8081)
+        .build();
+
+    RatpackServer.start(server -> server.serverConfig(serverConfig)
+        .registry(Guice.registry(bindings -> bindings
+            .moduleConfig(ServerTracingModule.class,
+                serverConfig.get("/zipkin", ZipkinConfig.class).toModuleConfig())
+            .binder(b ->
+                b.bind(String.class).annotatedWith(Names.named("backendEndpoint"))
+                    .toInstance(serverConfig.get("/backend/endpoint", String.class)))
+            .bind(Frontend.class)
+        ))
+        .handlers(chain -> chain
+            .get("health", ctx -> ctx.render("ok"))
+            .get("", ctx -> ctx.render(ctx.get(Frontend.class).callBackend()))
+        )
+    );
+  }
+}

--- a/ratpack/src/main/java/brave/example/ZipkinConfig.java
+++ b/ratpack/src/main/java/brave/example/ZipkinConfig.java
@@ -1,0 +1,45 @@
+package brave.example;
+
+import brave.sampler.Sampler;
+import ratpack.zipkin.ServerTracingModule;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+public final class ZipkinConfig {
+  String baseUrl = "http://127.0.0.1:9411";
+  String service;
+  boolean supportsJoin = true;
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public void setBaseUrl(String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
+  public String getService() {
+    return service;
+  }
+
+  public void setService(String service) {
+    this.service = service;
+  }
+
+  public boolean isSupportsJoin() {
+    return supportsJoin;
+  }
+
+  public void setSupportsJoin(boolean supportsJoin) {
+    this.supportsJoin = supportsJoin;
+  }
+
+  ServerTracingModule.Config toModuleConfig() {
+    return new ServerTracingModule.Config()
+        // TODO spanHandler
+        .spanReporterV2(AsyncReporter.create(URLConnectionSender.create(baseUrl + "/api/v2/spans")))
+        .serviceName(service)
+        // TODO supportsJoin
+        .sampler(Sampler.ALWAYS_SAMPLE);
+  }
+}

--- a/ratpack/src/main/resources/logback.xml
+++ b/ratpack/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{userName}] [%X{TraceId}] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This took some hints from https://github.com/openzipkin-contrib/brave-ratpack-example

I tried to not require a "ratpack." prefix, but if I used `.sysProps("")` bootstrap would crash I guess on too many other properties present. At least it did in Intellij. So, for now, I hacked around it by auto-prefixing.