### PR TITLE
wrong right curly brace

### DIFF
--- a/webmvc3-jetty/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/webmvc3-jetty/src/main/webapp/WEB-INF/applicationContext.xml
@@ -12,7 +12,7 @@
 
   <!-- Configuration for how to send spans to Zipkin -->
   <bean id="sender" class="zipkin2.reporter.beans.OkHttpSenderFactoryBean">
-    <property name="endpoint" value="${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans}"/>
+    <property name="endpoint" value="${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans"/>
   </bean>
 
   <!-- Configuration for how to buffer spans into messages for Zipkin -->

--- a/webmvc4-boot/src/main/java/brave/example/TracingAutoConfiguration.java
+++ b/webmvc4-boot/src/main/java/brave/example/TracingAutoConfiguration.java
@@ -61,7 +61,7 @@ public class TracingAutoConfiguration {
 
   /** Configuration for how to send spans to Zipkin */
   @Bean Sender sender(
-      @Value("${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans}") String zipkinEndpoint) {
+      @Value("${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans") String zipkinEndpoint) {
     return OkHttpSender.create(zipkinEndpoint);
   }
 

--- a/webmvc4-jetty/src/main/java/brave/example/TracingConfiguration.java
+++ b/webmvc4-jetty/src/main/java/brave/example/TracingConfiguration.java
@@ -66,7 +66,7 @@ public class TracingConfiguration {
 
   /** Configuration for how to send spans to Zipkin */
   @Bean Sender sender(
-      @Value("${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans}") String zipkinEndpoint) {
+      @Value("${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans") String zipkinEndpoint) {
     return OkHttpSender.create(zipkinEndpoint);
   }
 


### PR DESCRIPTION
The spring boot config zipkin.baseUrl is changed several days ago, at that time the right curly brace is accidentally got wrong, which makes the address invalid,
if you follow the README, the app will report 404 Not Found.
1. right address: /api/v2/spans
2. wrong address: /api/v2/spans%7D