### PR TITLE
Adds WebFlux+Reactor with Sleuth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Here are the example projects you can try:
   * Trace Instrumentation: [Brave Ratpack](https://github.com/openzipkin-contrib/brave-ratpack)
   * Trace Configuration: [Brave Ratpack Guice](https://github.com/openzipkin-contrib/brave-ratpack) [Java](ratpack/src/main/java/brave/example/Backend.java)
 
+* [webflux5-sleuth](webflux5-sleuth) `PROJECT=webflux5-sleuth docker-compose up`
+  * Runtime: Spring 5.2, Reactor Netty 0.9, Spring Boot 2.3, Spring Cloud Sleuth 2.2, Log4J 2.13, JRE 15
+  * Trace Instrumentation: [WebFlux Server](https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFilter.java), [WebFlux Client](https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java), [Reactor Context](https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
+  * Trace Configuration: [Spring Cloud Sleuth](https://github.com/spring-cloud/spring-cloud-sleuth/tree/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig) [Properties](webflux5-sleuth/src/main/resources/application.properties)
+
 * [webmvc25-jetty](webmvc25-jetty) `PROJECT=webmvc25-jetty docker-compose up`
   * Runtime: Spring 2.5, Apache HttpClient 4.3, Servlet 2.5, Jetty 7.6, Log4J 1.2, JRE 6
   * Trace Instrumentation: [Servlet](https://github.com/openzipkin/brave/tree/master/instrumentation/servlet), [Spring MVC](https://github.com/openzipkin/brave/tree/master/instrumentation/spring-webmvc), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [Log4J 1.2](https://github.com/openzipkin/brave/tree/master/context/log4j12)

--- a/docker/bin/install-example
+++ b/docker/bin/install-example
@@ -5,6 +5,7 @@ PROJECT=$1
 # Determine the platform explicitly or via convention
 case ${PROJECT} in
   armeria|dropwizard|ratpack) PLATFORM=java;;
+  webflux5-sleuth) PLATFORM=boot;;
   *) PLATFORM=$(echo "${PROJECT}"|cut -d- -f2);;
 esac
 

--- a/webflux5-sleuth/README.md
+++ b/webflux5-sleuth/README.md
@@ -1,0 +1,18 @@
+## Tracing Example: Spring WebFlux 5/Spring Boot 2.3/Spring Cloud Sleuth 2.2
+
+Instead of servlet, this uses Spring Boot 2.3 to create a self-contained
+application that runs Spring WebFlux 5 controllers.
+
+* brave.example.Frontend and Backend: Rest controllers
+* brave.example.AppAutoConfiguration: Sets up the WebClient used in the Frontend.
+
+Application code doesn't show any tracing configuration because that's handled
+by [Spring Cloud Sleuth v2](https://github.com/spring-cloud/spring-cloud-sleuth/tree/2.2.x), configured by properties.
+
+Version 2 of Sleuth was based on Brave. It provided auto-configuration of
+Brave libraries used in other projects, such as span reporting, logging context,
+sampling and instrumentation. This allowed end users to use properties for
+configuration instead of Java Config.
+
+In some cases, Sleuth used code that used Brave APIs, but not maintained by
+OpenZipkin. This example uses Sleuth's code for reporting spans and WebFlux. 

--- a/webflux5-sleuth/pom.xml
+++ b/webflux5-sleuth/pom.xml
@@ -1,0 +1,80 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave.example</groupId>
+    <artifactId>brave-example-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brave-example-webflux5-sleuth</artifactId>
+  <packaging>jar</packaging>
+
+  <name>brave-example-webflux5-sleuth</name>
+  <description>Tracing Example: Spring 5.2, Reactor Netty 0.9, Spring Boot 2.3, Spring Cloud Sleuth 2.2, Log4J 2.13, JRE 15</description>
+
+  <properties>
+    <jre.version>15</jre.version>
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+    <sleuth.version>2.2.5.RELEASE</sleuth.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Configures Spring Boot with WebFlux SLF4J logging -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+    <!-- Adds /actuator/health endpoint we re-map to /health used by our Docker HEALTHCHECK -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- spring-cloud-starter-zipkin configures instrumentation including what's in Brave and their own. -->
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-zipkin</artifactId>
+      <version>${sleuth.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- This can be overridden to brave.example.Frontend also -->
+          <mainClass>brave.example.Backend</mainClass>
+          <classifier>exec</classifier>
+          <executable>true</executable>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/webflux5-sleuth/src/main/java/brave/example/AppAutoConfiguration.java
+++ b/webflux5-sleuth/src/main/java/brave/example/AppAutoConfiguration.java
@@ -1,0 +1,14 @@
+package brave.example;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** The application is simple, it only uses WebFlux. */
+// This type makes support easier as forks can make a diff off a working AutoConfiguration type */
+@Configuration
+public class AppAutoConfiguration {
+  @Bean WebClient.Builder webClientBuilder() {
+    return WebClient.builder();
+  }
+}

--- a/webflux5-sleuth/src/main/java/brave/example/Backend.java
+++ b/webflux5-sleuth/src/main/java/brave/example/Backend.java
@@ -1,0 +1,30 @@
+package brave.example;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@EnableAutoConfiguration
+@RestController
+public class Backend {
+
+  @GetMapping("/api")
+  public Mono<String> printDate(@RequestHeader("user_name") Optional<String> username) {
+    return Mono.fromSupplier(() -> {
+      String date = LocalDate.now().toString();
+      return username.map(u -> date + " " + u).orElse(date);
+    });
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(Backend.class,
+        "--spring.application.name=backend",
+        "--server.port=9000"
+    );
+  }
+}

--- a/webflux5-sleuth/src/main/java/brave/example/Frontend.java
+++ b/webflux5-sleuth/src/main/java/brave/example/Frontend.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -12,7 +11,6 @@ import reactor.core.publisher.Mono;
 
 @EnableAutoConfiguration
 @RestController
-@CrossOrigin // So that javascript can be hosted elsewhere
 public class Frontend {
   final WebClient webClient;
 

--- a/webflux5-sleuth/src/main/java/brave/example/Frontend.java
+++ b/webflux5-sleuth/src/main/java/brave/example/Frontend.java
@@ -1,0 +1,34 @@
+package brave.example;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@EnableAutoConfiguration
+@RestController
+@CrossOrigin // So that javascript can be hosted elsewhere
+public class Frontend {
+  final WebClient webClient;
+
+  @Autowired Frontend(WebClient.Builder webClientBuilder,
+      @Value("${backend.endpoint:http://127.0.0.1:9000/api}") String backendEndpoint) {
+    this.webClient = webClientBuilder.baseUrl(backendEndpoint).build();
+  }
+
+  @GetMapping("/") public Mono<String> callBackend() {
+    return webClient.get().uri("").retrieve().bodyToMono(String.class);
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(Frontend.class,
+        "--spring.application.name=frontend",
+        "--server.port=8081"
+    );
+  }
+}

--- a/webflux5-sleuth/src/main/resources/META-INF/spring.factories
+++ b/webflux5-sleuth/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+brave.example.AppAutoConfiguration

--- a/webflux5-sleuth/src/main/resources/application.properties
+++ b/webflux5-sleuth/src/main/resources/application.properties
@@ -1,0 +1,26 @@
+# only expose /health from actuator
+management.endpoints.enabled-by-default=false
+management.endpoints.web.base-path=
+management.endpoints.web.path-mapping.health=/health
+management.endpoint.health.enabled=true
+
+# spring.application.name and server.port are set in the main methods,
+# so not done here
+
+# Propagates a field named 'user_name' downstream
+# Note: In Sleuth 2.x it is not yet possible to map user_name to correlation field userName.
+spring.sleuth.baggage.remote-fields=user_name
+spring.sleuth.baggage.correlation-fields=user_name
+spring.sleuth.sampler.probability=1.0
+# Sleuth has an unsampled path generator, but it doesn't notice remapped health endpoint
+spring.sleuth.web.additional-skip-pattern=/health
+
+# Map properties our example Docker image use to Sleuth ones
+spring.sleuth.supports-join=${brave.supportsJoin:true}
+spring.sleuth.trace-id128=${brave.traceId128Bit:false}
+spring.zipkin.baseUrl=${brave.zipkin.baseUrl:http://127.0.0.1:9411}
+spring.zipkin.service.name=${brave.localServiceName:${spring.application.name}}
+
+logging.level.root=INFO
+# Adds trace and span IDs to logs (when a trace is in progress)
+logging.pattern.level=[%X{user_name}] [%X{traceId}/%X{spanId}] %-5p [%t] %C{2} - %m%n

--- a/webmvc4-boot/src/main/java/brave/example/Frontend.java
+++ b/webmvc4-boot/src/main/java/brave/example/Frontend.java
@@ -5,14 +5,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
 @EnableAutoConfiguration
 @RestController
-@CrossOrigin // So that javascript can be hosted elsewhere
 public class Frontend {
   final RestTemplate restTemplate;
   final String backendEndpoint;

--- a/webmvc4-jetty/src/main/java/brave/example/Frontend.java
+++ b/webmvc4-jetty/src/main/java/brave/example/Frontend.java
@@ -2,7 +2,6 @@ package brave.example;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
@@ -10,7 +9,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @EnableWebMvc
 @RestController
-@CrossOrigin // So that javascript can be hosted elsewhere
 public class Frontend {
   final RestTemplate restTemplate;
   final String backendEndpoint;


### PR DESCRIPTION
This adds a Sleuth example in response to our consolidation of various -example
repos (brave-ratpack, armeria, sleuth-webmvc-example)

In general, this is effort conservation. For example, Apart from a couple polish
commits, @anuraaga and I were the only ones to maintain sleuth-webmvc-example in
the last 365 days. Here, we have automated testing and a consolidated way to
check known Brave clients in one place.

One thing not done here is merging in all branches of sleuth-webmvc-example.
All of the branches there showcased features in Brave and apply regardless of
configuration tool. This brings us to "Why WebFlux?"

WebFlux is the only example in sleuth-webmvc example using instrumentation not
yet in Brave.

Like all the other recent ones, this has been reworked conventionally. For
posterity, I created a new version of the same in sleuth-webmvc-example until
that repo is archived.

Note: @anuraaga @cjchand I think you are the only people who have used the
old images directly. We will no longer publish the old example into Docker.
You should update your usage to this (or a different tag for a different example):

openzipkin/example-sleuth-webmvc -> openzipkin/example-brave:webflux-sleuth

cc'ing for FYI purposes @marcingrzejszczak (current Sleuth maintainer) and
@violetagg (most helpful person in Reactor tracing)


![Screen Shot 2020-10-24 at 3 03 21 PM](https://user-images.githubusercontent.com/64215/97070525-94183d80-160b-11eb-9df5-4e32329b5a14.png)

```bash
$ curl -s localhost:8081
Sat Oct 24 06:53:06 GMT 2020
$ curl -s localhost:8081 -H'user_name: JC'
Sat Oct 24 06:53:15 GMT 2020 JC
```

```bash
$ docker-compose ps
  Name               Command                 State                    Ports              
-----------------------------------------------------------------------------------------
backend    start-brave-example backend    Up (healthy)   8081/tcp, 9000/tcp              
frontend   start-brave-example frontend   Up (healthy)   0.0.0.0:8081->8081/tcp, 9000/tcp
zipkin     start-zipkin                   Up (healthy)   0.0.0.0:9411->9411/tcp          
```

```bash
$ docker images|grep webflux5-sleuth
openzipkin/example-brave   webflux5-sleuth       a4e2e4553e43        About a minute ago   116MB
```