### PR TITLE
Publishes multi-architecture Docker images

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Build Docker image openzipkin/brave-example:${{ matrix.project }}-test
-        run:  docker/build_image ${{ matrix.project }} ${{ matrix.project }}-test
+        run:  docker/build_image ${{ matrix.project }} openzipkin/brave-example:${{ matrix.project }}-test
       - name: Verify Docker image openzipkin/brave-example:${{ matrix.project }}-test
         run: |
           # This just makes sure containers run and the HEALTHCHECK works (for now..)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,39 @@ language: bash
 services:
   - docker
 
-before_script:
-  # Log in to Docker Hub for releasing the image
-  - echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
 
-script: travis/publish.sh
+before_install:
+  # Ensure Docker buildx is available and can build multi-architecture
+  - |
+    # Enable experimental features on the server (multi-arch)
+    echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+    sudo service docker restart
+    # Enable experimental client features (eg docker buildx)
+    mkdir -p $HOME/.docker && echo '{"experimental":"enabled"}' > $HOME/.docker/config.json
+  - |
+    # Add buildx plugin
+    BUILDX_VERSION=0.4.2
+    BUILDX_URL=https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TRAVIS_CPU_ARCH}
+    mkdir -p $HOME/.docker/cli-plugins
+    ( cd $HOME/.docker/cli-plugins && wget -qO- $BUILDX_URL > docker-buildx && chmod 755 docker-buildx)
+    docker version
+  - |
+    # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
+    # See https://github.com/multiarch/qemu-user-static
+    if [ "$(uname -m)" = "x86_64" ]; then
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    fi
+    docker buildx create --name builder --use
+  - |
+    # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
+    # controlled by branch (typically only master). Check to see if a well-known env is available
+    # before attempting to log in.
+    if [[ -n "$GH_USER" ]]; then
+      # Log in to Docker Hub for releasing the image
+      echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
+    fi
+
+script: ./travis/publish.sh
 
 branches:
   only:
@@ -23,9 +51,11 @@ notifications:
     on_success: change
     on_failure: always
 
-env:
-  global:
-    # Ex. travis encrypt GH_USER=your_github_account
-    - secure: "jZs5FSpDPg/1Vo5fltYbLm0P8gc99Er0ql0uLqzbgDw2WdNXXbR8lk/gC6sqmrYryDSAo+yiEPV8oAy/6sL5DU+KVcg2YdR6WytCalS/LZO6wa0C2ZdUyfYQW9IgXzkejv3MF6n1OwVoiUva+VED+Oh4snKbeUU5ehLi4heqt/g="
-    # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX --add
-    - secure: "RUuzwjjIKPSqiKs0nQyAfCCm6lBkhn+HpjAph9x6NkN0myB308hVAw6Bqs99ZFvS432vkbpXkF0v91TKdWHlLuRsFgQs28Sk/j1sHvQhRo32YcDDrqEUyp3TPbSIjRvkINmgYQi2SPUPsYTgNU8X6z5u10EAgyB7xhLf3uBVe+Y="
+# When Travis, add to https://travis-ci.org/github/openzipkin/${REPO}/settings
+#
+# GH_TOKEN=XXX-https://github.com/settings/tokens-XXX
+#   - makes release commits and tags, also writes to GHCR if Docker
+#   - needs repo:status, public_repo and if Docker write:packages, delete:packages
+#   - referenced in .settings.xml
+#   - store like this: echo "https://$GH_TOKEN:@github.com" > .git/credentials
+# GH_USER=user_that_created_GH_TOKEN

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,5 +28,5 @@ To build an example, from the root directory, invoke `docker/build_image YOUR_PR
 
 Ex. To build the Armeria example as the image 'openzipkin/brave-example:test'
 ```bash
-$ docker/build_image armeria test
+$ docker/build_image armeria
 ```

--- a/docker/build_image
+++ b/docker/build_image
@@ -5,7 +5,10 @@
 # Java image mappings and ensures all metadata needed is taken from pom.xml.
 set -ue
 
-PROJECT=$1
+
+PROJECT=${1:-armeria}
+TAG=${2:-openzipkin/brave-example:test}
+OP=${3:-load}
 POM="${PROJECT}/pom.xml"
 
 if [ -f "${POM}" ]
@@ -17,31 +20,71 @@ else
   exit 1
 fi
 
-TAG=${2:-${PROJECT}}
+JAVA_VERSION=${JAVA_VERSION:-15.0.1_p9}
+
+# Arch of the running host. This determines which platform we load into Docker
+ARCH=${ARCH:-$(uname -m)}
+case ${ARCH} in
+  x86_64* )
+    ARCH=amd64
+    ;;
+  amd64* )
+    ;;
+  arm64* )
+    ;;
+  aarch64* )
+    ARCH=arm64
+    ;;
+  * )
+    echo ARCH ${ARCH} not yet supported in this script. export manually to amd64 or report issue.
+    exit 1
+esac
+
+# Platform to load into "docker images"
+PLATFORM=${PLATFORM:-linux/${ARCH}}
+# Platforms to eventually push to the registry
+PLATFORMS="linux/amd64,linux/arm64"
 
 case "${JRE_VERSION}" in
   6 )
     JRE_IMAGE=ghcr.io/openzipkin/java:6u119-6.22.0.3
+    # single arch image
+    PLATFORMS=linux/amd64
     ;;
   7 )
     JRE_IMAGE=ghcr.io/openzipkin/java:7u282-7.42.0.13
+    # single arch image
+    PLATFORMS=linux/amd64
     ;;
   8 )
-    JRE_IMAGE=ghcr.io/openzipkin/java:8u272-8.50.0.21-jre-headless
+    JRE_IMAGE=ghcr.io/openzipkin/java:8.252.09-jre
     ;;
   11 )
-    JRE_IMAGE=ghcr.io/openzipkin/java:11.0.9-11.43.21-jre
+    JRE_IMAGE=ghcr.io/openzipkin/java:11.0.9_p11-jre
     ;;
   15 )
-    JRE_IMAGE=ghcr.io/openzipkin/java:15.0.1-15.28.13-jre
+    JRE_IMAGE=ghcr.io/openzipkin/java:15.0.1_p9-jre
     ;;
   * )
     echo "Invalid JRE_VERSION: ${JRE_VERSION}"
     exit 1
 esac
 
-# Build the project
-docker build -f docker/Dockerfile -t openzipkin/brave-example:${TAG} \
-    --build-arg jre_image=${JRE_IMAGE} --build-arg project=${PROJECT} \
-    --label "description=${DESCRIPTION}" .
+BUILDX="docker buildx build --progress plain -f docker/Dockerfile \
+--build-arg project=${PROJECT} --label project=${PROJECT} \
+--build-arg jre_image=${JRE_IMAGE}"
 
+case ${OP} in
+  load )
+    # We can only load with one platform/arch https://github.com/docker/buildx/issues/59
+    echo "Building image ${TAG} with platform ${PLATFORM} and Java version ${JAVA_VERSION}"
+    ${BUILDX} --tag ${TAG} --platform=${PLATFORM} . --load
+    ;;
+  push )
+    echo "Pushing image ${TAG} with platforms ${PLATFORMS} and Java version ${JAVA_VERSION}"
+    ${BUILDX} --tag ${TAG} --label description="${DESCRIPTION}" --platform=${PLATFORMS} . --push
+    ;;
+  * )
+    echo "Invalid OP: ${OP}, Ex. load or push"
+    exit 1
+esac

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -4,8 +4,5 @@ set -ue
 
 ALL_PROJECTS=$(ls */pom.xml|sed 's~/pom.xml~~g')
 for PROJECT in ${ALL_PROJECTS}; do
-  docker/build_image "${PROJECT}"
-  IMAGE="openzipkin/brave-example:${PROJECT}"
-  docker tag $IMAGE ghcr.io/$IMAGE
-  docker push ghcr.io/$IMAGE
+  docker/build_image "${PROJECT}" "ghcr.io/openzipkin/brave-example:${PROJECT}" push
 done


### PR DESCRIPTION
Except the old JREs, this publishes multi-arch images.

This runs tests with linux/amd64, but publishes linux/amd64,linux/arm64.

See https://github.com/openzipkin/zipkin/issues/3141