### PR TITLE
Adds labels so that metadata shows in GitHub registry and tunes build

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   discover-projects:
@@ -37,6 +35,8 @@ jobs:
         uses: docker-practice/actions-setup-docker@master
         with:
           docker_version: 19.03
+          # Avoid pulling image from Docker Hub as it would consume pull quota
+          docker_buildx: false
       - name: Cache docker
         uses: actions/cache@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,23 @@
-# We only use travis to publish our Docker images
-dist: focal
-language: bash
+# Run `travis lint` when changing this file to avoid breaking the build.
+
+# We need a full VM so that testcontainers can use Docker
+# See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
+arch: amd64           # arm64 is LXD containers which we can't use because we run Docker tests
+os: linux             # required for arch different than amd64
+dist: focal           # newest available distribution
 
 services:
   - docker
 
-
+# Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
+# controlled by branch (typically only master). Check to see if a well-known env is available
+# before attempting to log in.
 before_install:
-  # Ensure Docker buildx is available and can build multi-architecture
   - |
-    # Enable experimental features on the server (multi-arch)
-    echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-    sudo service docker restart
-    # Enable experimental client features (eg docker buildx)
-    mkdir -p $HOME/.docker && echo '{"experimental":"enabled"}' > $HOME/.docker/config.json
-  - |
-    # Add buildx plugin
-    BUILDX_VERSION=0.4.2
-    BUILDX_URL=https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TRAVIS_CPU_ARCH}
-    mkdir -p $HOME/.docker/cli-plugins
-    ( cd $HOME/.docker/cli-plugins && wget -qO- $BUILDX_URL > docker-buildx && chmod 755 docker-buildx)
-    docker version
-  - |
-    # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
-    # See https://github.com/multiarch/qemu-user-static
-    if [ "$(uname -m)" = "x86_64" ]; then
-      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    fi
-    docker buildx create --name builder --use
-  - |
-    # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
-    # controlled by branch (typically only master). Check to see if a well-known env is available
-    # before attempting to log in.
     if [[ -n "$GH_USER" ]]; then
+      # re-use this condition to control if we prepare Docker for multi-arch
+      build-bin/setup_multiarch_docker
+
       # Log in to Docker Hub for releasing the image
       echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
     fi

--- a/build-bin/setup_multiarch_docker
+++ b/build-bin/setup_multiarch_docker
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -ue
+
+# Ensures Docker buildx is available and can build multi-architecture
+#
+# This should only happen when we are publishing multi-arch builds, as otherwise the setup will use
+# Docker Hub pull quota and possibly cause a build outage.
+
+# Verify we are on an arch that can publish multi-arch images
+ARCH=$(uname -m)
+if [ "$ARCH" != "x86_64" ]; then
+  echo "multiarch/qemu-user-static doesn't support arch $ARCH"
+  exit 1
+fi
+
+# Enable experimental features on the server (multi-arch)
+echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+sudo service docker restart
+# Enable experimental client features (eg docker buildx)
+mkdir -p ${HOME}/.docker && echo '{"experimental":"enabled"}' > ${HOME}/.docker/config.json
+
+# Add buildx plugin
+BUILDX_VERSION=0.4.2
+BUILDX_URL=https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TRAVIS_CPU_ARCH}
+mkdir -p $HOME/.docker/cli-plugins
+( cd $HOME/.docker/cli-plugins && wget -qO- $BUILDX_URL > docker-buildx && chmod 755 docker-buildx)
+docker version
+
+# Enable execution of different multi-architecture containers by QEMU and binfmt_misc
+# See https://github.com/multiarch/qemu-user-static
+docker run --rm --privileged ghcr.io/openzipkin/multiarch-qemu-user-static --reset -p yes
+docker buildx create --name builder --use

--- a/docker/bin/install-jetty-example
+++ b/docker/bin/install-jetty-example
@@ -13,7 +13,7 @@ jettyGroupId=$(mvn_property jetty.groupId)
 jettyVersion=$(mvn_property jetty.version)
 
 # Use Maven to get the jetty-runner so it is cached if multiple projects use it
-mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:get \
+mvn -q --batch-mode --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
     -Dtransitive=false -Dartifact=${jettyGroupId}:jetty-runner:${jettyVersion}:jar
 
 # Unzip the jetty-runner so that it is faster to start

--- a/docker/build_image
+++ b/docker/build_image
@@ -21,27 +21,6 @@ else
 fi
 
 JAVA_VERSION=${JAVA_VERSION:-15.0.1_p9}
-
-# Arch of the running host. This determines which platform we load into Docker
-ARCH=${ARCH:-$(uname -m)}
-case ${ARCH} in
-  x86_64* )
-    ARCH=amd64
-    ;;
-  amd64* )
-    ;;
-  arm64* )
-    ;;
-  aarch64* )
-    ARCH=arm64
-    ;;
-  * )
-    echo ARCH ${ARCH} not yet supported in this script. export manually to amd64 or report issue.
-    exit 1
-esac
-
-# Platform to load into "docker images"
-PLATFORM=${PLATFORM:-linux/${ARCH}}
 # Platforms to eventually push to the registry
 PLATFORMS="linux/amd64,linux/arm64"
 
@@ -70,21 +49,39 @@ case "${JRE_VERSION}" in
     exit 1
 esac
 
-BUILDX="docker buildx build --progress plain -f docker/Dockerfile \
---build-arg project=${PROJECT} --label project=${PROJECT} \
---build-arg jre_image=${JRE_IMAGE}"
+DOCKER_ARGS="-f docker/Dockerfile --tag ${TAG} \
+--build-arg project=${PROJECT} --label brave-example=${PROJECT} \
+--build-arg jre_image=${JRE_IMAGE} \
+--label org.opencontainers.image.source=https://github.com/openzipkin/brave-example \
+--label org.opencontainers.image.version=$(git rev-parse --short HEAD) ."
 
-case ${OP} in
-  load )
-    # We can only load with one platform/arch https://github.com/docker/buildx/issues/59
-    echo "Building image ${TAG} with platform ${PLATFORM} and Java version ${JAVA_VERSION}"
-    ${BUILDX} --tag ${TAG} --platform=${PLATFORM} . --load
+# Avoid buildx for two reasons:
+#  * It only supports one platform/arch on load https://github.com/docker/buildx/issues/59
+#  * It would pull Docker Hub for moby/buildkit or multiarch/qemu-user-static images, using up quota
+if [ "${OP}" = "load" ]; then
+  echo "Building image ${TAG} with java_version ${JAVA_VERSION}"
+  docker build --label org.opencontainers.image.description="${DESCRIPTION}" ${DOCKER_ARGS}
+  exit $?
+fi
+
+if [ "${OP}" != "push" ]; then
+  echo "Invalid OP: ${OP}, Ex. load or push"
+  exit 1
+fi
+
+
+# This can be less manual in the future, for example checking buildx to see what it can do.
+ARCH=${ARCH:-$(uname -m)}
+case ${ARCH} in
+  x86_64* )
     ;;
-  push )
-    echo "Pushing image ${TAG} with platforms ${PLATFORMS} and Java version ${JAVA_VERSION}"
-    ${BUILDX} --tag ${TAG} --label description="${DESCRIPTION}" --platform=${PLATFORMS} . --push
+  amd64* )
     ;;
   * )
-    echo "Invalid OP: ${OP}, Ex. load or push"
+    echo Pushing platforms ${PLATFORMS} with arch ${ARCH} is not yet supported.
     exit 1
 esac
+
+echo "Pushing image ${TAG} with platforms ${PLATFORMS} and Java version ${JAVA_VERSION}"
+docker buildx build --progress plain --platform=${PLATFORMS} \
+       --label org.opencontainers.image.description="${DESCRIPTION}" ${DOCKER_ARGS} --push


### PR DESCRIPTION
This adds labels so that https://github.com/orgs/openzipkin/packages/container/brave-example
doesn't show nothing. It also ensures buildx is only used when needed as
that implies some Docker Hub quota.