### PR TITLE
Updates to Spring Boot 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here are the example projects you can try:
   * Trace Configuration: [Brave Ratpack Guice](https://github.com/openzipkin-contrib/brave-ratpack) [Java](ratpack/src/main/java/brave/example/Backend.java)
 
 * [webflux5-sleuth](webflux5-sleuth) `PROJECT=webflux5-sleuth docker-compose up`
-  * Runtime: Spring 5.2, Reactor Netty 0.9, Spring Boot 2.3, Spring Cloud Sleuth 2.2, Log4J 2.13, JRE 15
+  * Runtime: Spring 5.3, Reactor Netty 1.0, Spring Boot 2.4, Spring Cloud Sleuth 2.2, Log4J 2.13, JRE 15
   * Trace Instrumentation: [WebFlux Server](https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFilter.java), [WebFlux Client](https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java), [Reactor Context](https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
   * Trace Configuration: [Spring Cloud Sleuth](https://github.com/spring-cloud/spring-cloud-sleuth/tree/2.2.x/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig) [Properties](webflux5-sleuth/src/main/resources/application.properties)
 

--- a/webflux5-sleuth/pom.xml
+++ b/webflux5-sleuth/pom.xml
@@ -13,13 +13,13 @@
   <packaging>jar</packaging>
 
   <name>brave-example-webflux5-sleuth</name>
-  <description>Tracing Example: Spring 5.2, Reactor Netty 0.9, Spring Boot 2.3, Spring Cloud Sleuth 2.2, Log4J 2.13, JRE 15</description>
+  <description>Tracing Example: Spring 5.3, Reactor Netty 1.0, Spring Boot 2.4, Spring Cloud Sleuth 2.2, Log4J 2.13, JRE 15</description>
 
   <properties>
     <jre.version>15</jre.version>
     <maven.compiler.release>8</maven.compiler.release>
 
-    <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
+    <spring-boot.version>2.4.0</spring-boot.version>
     <sleuth.version>2.2.6.RELEASE</sleuth.version>
   </properties>
 

--- a/webflux5-sleuth/pom.xml
+++ b/webflux5-sleuth/pom.xml
@@ -31,6 +31,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Sleuth's BOM pins an old version of Brave. Order this before to avoid that. -->
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-bom</artifactId>
+        <version>${brave.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>

--- a/webflux5-sleuth/pom.xml
+++ b/webflux5-sleuth/pom.xml
@@ -20,7 +20,6 @@
     <maven.compiler.release>8</maven.compiler.release>
 
     <spring-boot.version>2.4.0</spring-boot.version>
-    <sleuth.version>2.2.6.RELEASE</sleuth.version>
   </properties>
 
   <dependencyManagement>
@@ -29,6 +28,14 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <!-- Hoxton includes Spring Cloud Sleuth 2.2.x -->
+        <version>Hoxton.SR9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -47,11 +54,14 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
-    <!-- spring-cloud-starter-zipkin configures instrumentation including what's in Brave and their own. -->
+    <!-- spring-cloud-starter-zipkin was removed in Spring Cloud 3.0, so add this manually. -->
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-zipkin</artifactId>
-      <version>${sleuth.version}</version>
+      <artifactId>spring-cloud-starter-sleuth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-sleuth-zipkin</artifactId>
     </dependency>
   </dependencies>
 

--- a/webflux5-sleuth/pom.xml
+++ b/webflux5-sleuth/pom.xml
@@ -20,6 +20,7 @@
     <maven.compiler.release>8</maven.compiler.release>
 
     <spring-boot.version>2.4.0</spring-boot.version>
+    <sleuth.version>2.2.6.RELEASE</sleuth.version>
   </properties>
 
   <dependencyManagement>
@@ -28,22 +29,6 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Sleuth's BOM pins an old version of Brave. Order this before to avoid that. -->
-      <dependency>
-        <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave-bom</artifactId>
-        <version>${brave.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <!-- Hoxton includes Spring Cloud Sleuth 2.2.x -->
-        <version>Hoxton.SR9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -62,14 +47,17 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
-    <!-- spring-cloud-starter-zipkin was removed in Spring Cloud 3.0, so add this manually. -->
+    <!-- spring-cloud-starter-zipkin was removed in Spring Cloud 3.0, so add manually.
+         This also avoids NoClassDefFoundError from mismatch with spring-cloud-context per #71 -->
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-sleuth</artifactId>
+      <artifactId>spring-cloud-sleuth-core</artifactId>
+      <version>${sleuth.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-sleuth-zipkin</artifactId>
+      <version>${sleuth.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
@marcingrzejszczak @spencergibb It seems sleuth 2.2.x doesn't align right with boot 2.4 no matter how many BOMs I shuffle. Is it a work in progress, or not expected to work?

```
2020-11-21 23:04:22.629 ERROR [frontend,,,] 50492 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'configurationPropertiesBeans' defined in class path resource [org/springframework/cloud/autoconfigure/ConfigurationPropertiesRebinderAutoConfiguration.class]: Post-processing of merged bean definition failed; nested exception is java.lang.IllegalStateException: Failed to introspect Class [org.springframework.cloud.context.properties.ConfigurationPropertiesBeans] from ClassLoader [jdk.internal.loader.ClassLoaders$AppClassLoader@73d16e93]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:586) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:531) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.registerBeanPostProcessors(PostProcessorRegistrationDelegate.java:244) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.support.AbstractApplicationContext.registerBeanPostProcessors(AbstractApplicationContext.java:767) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:572) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:767) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:759) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:426) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:326) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:144) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.bootstrapServiceContext(BootstrapApplicationListener.java:212) ~[spring-cloud-context-2.2.6.RELEASE.jar:2.2.6.RELEASE]
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.onApplicationEvent(BootstrapApplicationListener.java:117) ~[spring-cloud-context-2.2.6.RELEASE.jar:2.2.6.RELEASE]
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.onApplicationEvent(BootstrapApplicationListener.java:74) ~[spring-cloud-context-2.2.6.RELEASE.jar:2.2.6.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:203) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:196) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:170) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:148) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:82) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplicationRunListeners.lambda$environmentPrepared$2(SpringApplicationRunListeners.java:63) ~[spring-boot-2.4.0.jar:2.4.0]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511) ~[na:na]
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:117) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:111) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:62) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:362) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:320) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1309) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1298) ~[spring-boot-2.4.0.jar:2.4.0]
	at brave.example.Frontend.main(Frontend.java:27) ~[classes/:na]
Caused by: java.lang.IllegalStateException: Failed to introspect Class [org.springframework.cloud.context.properties.ConfigurationPropertiesBeans] from ClassLoader [jdk.internal.loader.ClassLoaders$AppClassLoader@73d16e93]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:481) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.util.ReflectionUtils.doWithLocalMethods(ReflectionUtils.java:321) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.buildLifecycleMetadata(InitDestroyAnnotationBeanPostProcessor.java:232) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.findLifecycleMetadata(InitDestroyAnnotationBeanPostProcessor.java:210) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessMergedBeanDefinition(InitDestroyAnnotationBeanPostProcessor.java:149) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.CommonAnnotationBeanPostProcessor.postProcessMergedBeanDefinition(CommonAnnotationBeanPostProcessor.java:294) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyMergedBeanDefinitionPostProcessors(AbstractAutowireCapableBeanFactory.java:1100) ~[spring-beans-5.3.1.jar:5.3.1]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:583) ~[spring-beans-5.3.1.jar:5.3.1]
	... 31 common frames omitted
Caused by: java.lang.NoClassDefFoundError: org/springframework/boot/context/properties/ConfigurationBeanFactoryMetadata
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method) ~[na:na]
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3325) ~[na:na]
	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2466) ~[na:na]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:463) ~[spring-core-5.3.1.jar:5.3.1]
	... 38 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:606) ~[na:na]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:168) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[na:na]
	... 42 common frames omitted
```

```
[INFO] +- org.springframework.cloud:spring-cloud-starter-sleuth:jar:2.2.6.RELEASE:compile
[INFO] |  +- org.springframework.cloud:spring-cloud-starter:jar:2.2.6.RELEASE:compile
[INFO] |  |  +- org.springframework.cloud:spring-cloud-context:jar:2.2.6.RELEASE:compile
[INFO] |  |  \- org.springframework.security:spring-security-rsa:jar:1.0.9.RELEASE:compile
[INFO] |  |     \- org.bouncycastle:bcpkix-jdk15on:jar:1.64:compile
[INFO] |  |        \- org.bouncycastle:bcprov-jdk15on:jar:1.64:compile
[INFO] |  +- org.springframework.boot:spring-boot-starter-aop:jar:2.4.0:compile
[INFO] |  |  +- org.springframework:spring-aop:jar:5.3.1:compile
[INFO] |  |  \- org.aspectj:aspectjweaver:jar:1.9.6:compile
[INFO] |  \- org.springframework.cloud:spring-cloud-sleuth-core:jar:2.2.6.RELEASE:compile
[INFO] |     +- org.springframework:spring-context:jar:5.3.1:compile
[INFO] |     |  \- org.springframework:spring-expression:jar:5.3.1:compile
[INFO] |     +- org.aspectj:aspectjrt:jar:1.9.6:compile
[INFO] |     +- io.zipkin.brave:brave:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-context-slf4j:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-messaging:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-rpc:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-spring-web:jar:5.13.1:compile
[INFO] |     |  \- io.zipkin.brave:brave-instrumentation-http:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-spring-rabbit:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-kafka-clients:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-kafka-streams:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-httpclient:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-httpasyncclient:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-spring-webmvc:jar:5.13.1:compile
[INFO] |     |  \- io.zipkin.brave:brave-instrumentation-servlet:jar:5.13.1:compile
[INFO] |     +- io.zipkin.brave:brave-instrumentation-jms:jar:5.13.1:compile
[INFO] |     \- io.zipkin.reporter2:zipkin-reporter-metrics-micrometer:jar:2.16.0:compile
[INFO] \- org.springframework.cloud:spring-cloud-sleuth-zipkin:jar:2.2.6.RELEASE:compile
[INFO]    +- org.springframework.cloud:spring-cloud-commons:jar:2.2.6.RELEASE:compile
[INFO]    |  \- org.springframework.security:spring-security-crypto:jar:5.4.1:compile
[INFO]    +- io.zipkin.zipkin2:zipkin:jar:2.22.2:compile
[INFO]    +- io.zipkin.reporter2:zipkin-reporter:jar:2.16.0:compile
[INFO]    +- io.zipkin.reporter2:zipkin-reporter-brave:jar:2.16.0:compile
[INFO]    +- io.zipkin.reporter2:zipkin-sender-kafka:jar:2.16.0:compile
[INFO]    +- io.zipkin.reporter2:zipkin-sender-activemq-client:jar:2.16.0:compile
[INFO]    \- io.zipkin.reporter2:zipkin-sender-amqp-client:jar:2.16.0:compile

```