### PR TITLE
Updated for Boot 2.4 and Sleuth M5

### DIFF
--- a/webflux5-sleuth/README.md
+++ b/webflux5-sleuth/README.md
@@ -1,18 +1,18 @@
 ## Tracing Example: Spring WebFlux 5/Spring Boot 2.3/Spring Cloud Sleuth 2.2
 
-Instead of servlet, this uses Spring Boot 2.3 to create a self-contained
+Instead of servlet, this uses Spring Boot 2.4 to create a self-contained
 application that runs Spring WebFlux 5 controllers.
 
 * brave.example.Frontend and Backend: Rest controllers
 * brave.example.AppAutoConfiguration: Sets up the WebClient used in the Frontend.
 
 Application code doesn't show any tracing configuration because that's handled
-by [Spring Cloud Sleuth v2](https://github.com/spring-cloud/spring-cloud-sleuth/tree/2.2.x), configured by properties.
+by [Spring Cloud Sleuth v3](https://github.com/spring-cloud/spring-cloud-sleuth/master), configured by properties.
 
-Version 2 of Sleuth was based on Brave. It provided auto-configuration of
+Version 3 of Sleuth supports Brave. It provides auto-configuration of
 Brave libraries used in other projects, such as span reporting, logging context,
-sampling and instrumentation. This allowed end users to use properties for
+sampling and instrumentation. This allows end users to use properties for
 configuration instead of Java Config.
 
 In some cases, Sleuth used code that used Brave APIs, but not maintained by
-OpenZipkin. This example uses Sleuth's code for reporting spans and WebFlux. 
+OpenZipkin. This example uses Sleuth's code for reporting spans and WebFlux.

--- a/webflux5-sleuth/pom.xml
+++ b/webflux5-sleuth/pom.xml
@@ -19,8 +19,8 @@
     <jre.version>15</jre.version>
     <maven.compiler.release>8</maven.compiler.release>
 
-    <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
-    <sleuth.version>2.2.6.RELEASE</sleuth.version>
+    <spring-boot.version>2.4.0</spring-boot.version>
+    <sleuth.version>3.0.0-M5</sleuth.version>
   </properties>
 
   <dependencyManagement>
@@ -47,10 +47,16 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
-    <!-- spring-cloud-starter-zipkin configures instrumentation including what's in Brave and their own. -->
+    <!-- spring-cloud-starter-sleuth configures instrumentation including what's in Brave and their own. -->
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-zipkin</artifactId>
+      <artifactId>spring-cloud-starter-sleuth</artifactId>
+      <version>${sleuth.version}</version>
+    </dependency>
+    <!-- spring-cloud-sleuth-zipkin configures zipkin -->
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-sleuth-zipkin</artifactId>
       <version>${sleuth.version}</version>
     </dependency>
   </dependencies>
@@ -77,4 +83,79 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>spring</id>
+      <repositories>
+        <repository>
+          <id>spring-snapshots</id>
+          <name>Spring Snapshots</name>
+          <url>https://repo.spring.io/snapshot</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </repository>
+        <!-- BRAVE & OTEL -->
+        <repository>
+          <id>jfrog-snapshots</id>
+          <name>JFrog Snapshots</name>
+          <url>https://oss.jfrog.org/oss-snapshot-local/</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </repository>
+        <repository>
+          <id>spring-milestones</id>
+          <name>Spring Milestones</name>
+          <url>https://repo.spring.io/milestone</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>spring-releases</id>
+          <name>Spring Releases</name>
+          <url>https://repo.spring.io/release</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>spring-snapshots</id>
+          <name>Spring Snapshots</name>
+          <url>https://repo.spring.io/snapshot</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </pluginRepository>
+        <pluginRepository>
+          <id>spring-milestones</id>
+          <name>Spring Milestones</name>
+          <url>https://repo.spring.io/milestone</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>spring-releases</id>
+          <name>Spring Releases</name>
+          <url>https://repo.spring.io/release</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
I've forgotten that in the example you're not using any sleuth API. So the transition was pretty straight-forward and there should bo no changes required when Sleuth M6 is released.