### PR TITLE
Adds Jersey, DataStax Java Driver 3.x, Apache Cassandra 3.x example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 # Allow on-demand "mvn package".
 !armeria/src/main/**
 !dropwizard/src/main/**
+!jersey2-cassandra3/src/main/**
 !ratpack/src/main/**
 !webflux5-sleuth/src/main/**
 !webmvc3-jetty/src/main/**

--- a/README.md
+++ b/README.md
@@ -43,8 +43,13 @@ Here are the example projects you can try:
 
 * [dropwizard](dropwizard) `PROJECT=dropwizard docker-compose up`
   * Runtime: JaxRS 2, Jersey 2.31, Apache HttpClient 4.5, Jetty 9.4, SLF4J 1.7, JRE 15
-  * Trace Instrumentation: [Jersey Server](https://github.com/openzipkin/brave/tree/master/instrumentation/jersey-server), [JaxRS 2](https://github.com/openzipkin/brave/tree/master/instrumentation/jaxrs2), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
+  * Trace Instrumentation: [Jersey Server](https://github.com/openzipkin/brave/tree/master/instrumentation/jersey-server), [Apache HttpClient](https://github.com/openzipkin/brave/tree/master/instrumentation/httpclient), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
   * Trace Configuration: [Dropwizard Zipkin](https://github.com/smoketurner/dropwizard-zipkin) [Java](dropwizard/src/main/java/brave/example/ExampleApplication.java) [Yaml](dropwizard/src/main/resources/server.yml)
+
+* [jersey2-cassandra3](jersey2-cassandra3) `PROJECT=jersey2-cassandra3 docker-compose up`
+  * Runtime: JaxRS 2, Jersey 2.32, DataStax Java Driver 3.0, Apache Cassandra 3.11, SLF4J 1.7, JRE 8
+  * Trace Instrumentation: [Jersey Server](https://github.com/openzipkin/brave/tree/master/instrumentation/jersey-server), [DataStax Java Driver](https://github.com/openzipkin/brave-cassandra/tree/master/cassandra-driver), [Apache Cassandra](https://github.com/openzipkin/brave-cassandra/tree/master/cassandra), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
+  * Trace Configuration: [Brave API](https://github.com/openzipkin/brave/tree/master/brave#setup) [XML](jersey2-cassandra3/src/main/webapp/WEB-INF/tracing.xml)
 
 * [ratpack](ratpack) `PROJECT=ratpack docker-compose up`
   * Runtime: Ratpack 1.8, Guice 4, SLF4J 1.7, JRE 15

--- a/build-bin/docker-compose.test.yml
+++ b/build-bin/docker-compose.test.yml
@@ -19,7 +19,7 @@ services:
     image: ghcr.io/openzipkin/alpine:3.12.1
     entrypoint: /bin/sh
     # Pass a trace header with a constant trace ID, so that we know what to look for later
-    command: "-c \"wget -qO- --header 'b3: cafebabecafebabe-cafebabecafebabe-1' http://frontend:8081 >/dev/null\""
+    command: "-c \"wget -qO- --header 'b3: cafebabecafebabe-cafebabecafebabe-1' http://frontend:8081\""
     depends_on:
       frontend:
         condition: service_healthy

--- a/docker/bin/install-example
+++ b/docker/bin/install-example
@@ -70,6 +70,7 @@ case ${version} in
   dropwizard ) /code/docker/bin/post-install-example-dropwizard;;
   # Ratpack system properties must be prefixed with "ratpack."
   ratpack ) sed -i 's/-D/-Dratpack./g' start-frontend start-backend;;
+  *-cassandra3 ) /code/docker/bin/post-install-example-cassandra;;
 esac
 
 chmod 755 *

--- a/docker/bin/post-install-example-cassandra
+++ b/docker/bin/post-install-example-cassandra
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eux
+
+# Ensure the process binds to the host IP, not localhost as is used in the IDE
+sed -i 's~JAVA_OPTS=~sed -i "s/127.0.0.1/$IP/g" classes/cassandra.yaml\n\nJAVA_OPTS=~' start-backend
+
+# Communication isn't HTTP
+sed -i 's~endpoint=http://\(.*\)/api~contactPoint=\1~' start-frontend
+sed -i 's/HEALTHCHECK_KIND=http/HEALTHCHECK_KIND=tcp/g' start-backend
+
+# Cassandra needs more than 32m memory
+sed -i 's/32m/128m/g' start-backend

--- a/jersey2-cassandra3/RATIONALE.md
+++ b/jersey2-cassandra3/RATIONALE.md
@@ -1,0 +1,27 @@
+## Why JRE 8?
+Apache Cassandra 3.x doesn't formally support JRE above 8, even if Zipkin has
+some tricks to allow that. By using a normal JRE, we are able to keep the
+example closer to real life.
+
+*Note:* A DataStax Driver 4.x + Apache Cassandra 4.x example will be different.
+
+## Why Jersey?
+We need a simple frontend which doesn't add problems to an already fragile
+classpath. Hence, this uses Jersey as the frontend with
+`com.sun.net.httpserver.HttpServer`.
+
+This is mostly to avoid conflicts with Guava and Netty, allowing a compatible
+classpath for both the frontend and backend. Doing so eases the IDE experience:
+You can debug the frontend and backend just like any other example.
+
+The main thing we have to manage are things already managed in Apache Cassandra
+3.x. Notably, it uses the DataStax driver internally, implying they've solved
+Netty and Guava conflicts.
+
+## Why Spring XML?
+Jersey requires HK2 or CDI injection. We don't currently have CDI integration
+with Brave, else we would use that.
+
+There are some external ways to use integrate Spring with Jersey, but it is
+confusing. Instead, we hide Spring inside `TracingConfiguration`. Internally,
+this uses XML as it is declarative, but we could have easily used Java Config.

--- a/jersey2-cassandra3/README.md
+++ b/jersey2-cassandra3/README.md
@@ -1,0 +1,12 @@
+## Tracing Example: Jersey 2.32/DataStax Java Driver 3.10/Apache Cassandra 3.11/JRE 8
+
+Instead of servlet, the frontend is a Jersey application. The backend is Apache Cassandra 3.x.
+Requests from the frontend to the backend are via [DataStax Java Driver](https://github.com/datastax/java-driver) 3.x.
+Both services run as a normal Java application.
+
+* [brave.example.Frontend](src/main/java/brave/example/Frontend.java) - HTTP controller and DataStax Java Driver
+  * [tracing.xml](src/main/resources/tracing.xml) configures basic tracing functions. 
+* [brave.example.Backend](src/main/java/brave/example/Backend.java) - Sets system properties and runs `CassandraDaemon`
+
+Here's an example screen shot:
+![screen shot](https://user-images.githubusercontent.com/64215/100691758-581f8780-33c4-11eb-8451-2ad9c52a0e08.png)

--- a/jersey2-cassandra3/pom.xml
+++ b/jersey2-cassandra3/pom.xml
@@ -28,7 +28,6 @@
     <!-- Use the cassandra-driver-core version bundled in cassandra to not conflict with Netty. -->
     <cassandra-driver-core.version>3.0.1</cassandra-driver-core.version>
 
-
     <!-- https://github.com/openzipkin/brave-cassandra -->
     <brave-cassandra.version>0.11.0</brave-cassandra.version>
   </properties>

--- a/jersey2-cassandra3/pom.xml
+++ b/jersey2-cassandra3/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave.example</groupId>
+    <artifactId>brave-example-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../parent-pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brave-example-jersey2-cassandra3</artifactId>
+  <packaging>jar</packaging>
+
+  <name>brave-example-jersey2-cassandra3</name>
+  <description>Tracing Example: Jersey 2/DataStax Java Driver 3.10/Apache Cassandra 3.11/JRE 8</description>
+
+  <properties>
+    <jre.version>8</jre.version>
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- Use a container that doesn't use Netty. -->
+    <jersey.version>2.32</jersey.version>
+    <spring.version>4.3.29.RELEASE</spring.version>
+
+    <cassandra.version>3.11.9</cassandra.version>
+    <!-- Use the cassandra-driver-core version bundled in cassandra to not conflict with Netty. -->
+    <cassandra-driver-core.version>3.0.1</cassandra-driver-core.version>
+
+
+    <!-- https://github.com/openzipkin/brave-cassandra -->
+    <brave-cassandra.version>0.11.0</brave-cassandra.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-jdk-http</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <!-- Instruments the underlying HTTP requests -->
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-jersey-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>${cassandra.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Instruments the underlying Cassandra server requests -->
+    <dependency>
+      <groupId>io.zipkin.brave.cassandra</groupId>
+      <artifactId>brave-instrumentation-cassandra</artifactId>
+      <version>${brave-cassandra.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>${cassandra-driver-core.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Instruments the underlying Cassandra client requests -->
+    <dependency>
+      <groupId>io.zipkin.brave.cassandra</groupId>
+      <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+      <version>${brave-cassandra.version}</version>
+    </dependency>
+
+    <!-- Integrates so you can use log patterns like %X{traceId}/%X{spanId} -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-context-slf4j</artifactId>
+    </dependency>
+
+    <!-- The below are needed to report traces to http://127.0.0.1:9411/api/v2/spans -->
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter-brave</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-urlconnection</artifactId>
+    </dependency>
+
+    <!-- Allows loading of trace configuration declaratively -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-spring-beans</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/jersey2-cassandra3/src/main/java/brave/example/Backend.java
+++ b/jersey2-cassandra3/src/main/java/brave/example/Backend.java
@@ -1,0 +1,39 @@
+package brave.example;
+
+import brave.cassandra.Tracing;
+import java.io.File;
+import org.apache.cassandra.service.CassandraDaemon;
+
+/**
+ * We construct arguments to {@link CassandraDaemon} in the typically named entrypoint class for a
+ * couple reasons. One is to keep examples decoupled from implementation details. Another is that
+ * this allows someone to run this in their IDE easily, without needing to know special knowledge
+ * about Cassandra. For example set a debugger break point in {@link Tracing}, if they want to see
+ * what's going on.
+ */
+public final class Backend {
+  public static void main(String[] args) {
+    // Setup basic Cassandra properties that could otherwise be set at runtime.
+    String port = System.getenv("PORT");
+    if (port != null) System.setProperty("cassandra.native_transport_port", port);
+    File scratchDir = new File(System.getProperty("user.dir") + "/target");
+    if (!scratchDir.exists()) scratchDir.mkdir();
+    System.setProperty("cassandra-foreground", "yes");
+    System.setProperty("cassandra.storagedir", scratchDir.getAbsolutePath());
+    System.setProperty("cassandra.triggers_dir", scratchDir.getAbsolutePath());
+    System.setProperty("cassandra.config", "cassandra.yaml");
+
+    // Tracing integration is via "cassandra.custom_tracing_class", which defaults to initialize
+    // statically. We are using this approach solely to show out-of-box experience.
+    // The implementation can be extended to initialize from Spring or another config provider.
+    System.setProperty("zipkin.http_endpoint",
+        System.getProperty("zipkin.baseUrl", "http://127.0.0.1:9411") + "/api/v2/spans");
+    System.setProperty("zipkin.fail_fast", "true");
+    System.setProperty("zipkin.service_name",
+        System.getProperty("brave.localServiceName", "backend"));
+    System.setProperty("cassandra.custom_tracing_class", Tracing.class.getName());
+
+    // Dispatch to the normal Cassandra entrypoint class
+    CassandraDaemon.main(args);
+  }
+}

--- a/jersey2-cassandra3/src/main/java/brave/example/Frontend.java
+++ b/jersey2-cassandra3/src/main/java/brave/example/Frontend.java
@@ -1,0 +1,73 @@
+package brave.example;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.google.common.net.HostAndPort;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.Date;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.ext.RuntimeDelegate;
+import org.glassfish.jersey.server.ResourceConfig;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public final class Frontend {
+  @Path("")
+  public static class Resource {
+    final Session session;
+    final PreparedStatement preparedStatement;
+
+    Resource(Session session) {
+      this.session = session;
+      // Normal backend example returns the date, possibly with "userName" baggage field.
+      // There's no current way to select baggage inside CQL, so we skip it and just print the date.
+      this.preparedStatement = session.prepare("SELECT toTimestamp(now()) from system.local");
+    }
+
+    @GET public String callBackend() {
+      Date date = session.execute(preparedStatement.bind()).one().getTimestamp(0);
+      return date + "\n";
+    }
+  }
+
+  /** Fake /health endpoint that allows us to ensure our HEALTHCHECK doesn't start traces. */
+  public static class HealthCheck implements HttpHandler {
+    static final byte[] body = "ok\n".getBytes(UTF_8);
+
+    @Override public void handle(HttpExchange exchange) throws IOException {
+      exchange.sendResponseHeaders(200, body.length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(body);
+      }
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    String contactPointString = System.getProperty("backend.contactPoint", "127.0.0.1:9042");
+    HostAndPort parsed = HostAndPort.fromString(contactPointString).withDefaultPort(9042);
+    Cluster cluster = Cluster.builder()
+        .addContactPointsWithPorts(new InetSocketAddress(parsed.getHostText(), parsed.getPort()))
+        .build();
+    Runtime.getRuntime().addShutdownHook(new Thread(cluster::close));
+
+    TracingConfiguration tracing = TracingConfiguration.create("frontend");
+    ResourceConfig config = new ResourceConfig();
+    config.register(new Resource(tracing.tracingSession(cluster.connect(), "backend")));
+    config.register(tracing.tracingListener());
+    HttpHandler handler = RuntimeDelegate.getInstance().createEndpoint(config, HttpHandler.class);
+
+    HttpServer server = HttpServer.create(new InetSocketAddress(8081), 0);
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> server.stop(0)));
+    server.createContext("/", handler);
+    server.createContext("/health", new HealthCheck());
+    server.start();
+    Thread.currentThread().join();
+  }
+}

--- a/jersey2-cassandra3/src/main/java/brave/example/TracingConfiguration.java
+++ b/jersey2-cassandra3/src/main/java/brave/example/TracingConfiguration.java
@@ -1,0 +1,37 @@
+package brave.example;
+
+import brave.Tracing;
+import brave.cassandra.driver.CassandraClientTracing;
+import brave.cassandra.driver.TracingSession;
+import brave.http.HttpTracing;
+import brave.jersey.server.TracingApplicationEventListener;
+import com.datastax.driver.core.Session;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+final class TracingConfiguration {
+  ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("tracing.xml");
+
+  static TracingConfiguration create(String defaultServiceName) {
+    if (System.getProperty("brave.localServiceName") == null) {
+      System.setProperty("brave.localServiceName", defaultServiceName);
+    }
+    TracingConfiguration result = new TracingConfiguration();
+    Runtime.getRuntime().addShutdownHook(new Thread(result.context::close));
+    return result;
+  }
+
+  Tracing tracing() {
+    return context.getBean(Tracing.class);
+  }
+
+  Session tracingSession(Session delegate, String remoteServiceName) {
+    CassandraClientTracing cassandraTracing = CassandraClientTracing.newBuilder(tracing())
+        .propagationEnabled(true).remoteServiceName(remoteServiceName).build();
+    return TracingSession.create(cassandraTracing, delegate);
+  }
+
+  ApplicationEventListener tracingListener() {
+    return TracingApplicationEventListener.create(context.getBean(HttpTracing.class));
+  }
+}

--- a/jersey2-cassandra3/src/main/resources/cassandra.yaml
+++ b/jersey2-cassandra3/src/main/resources/cassandra.yaml
@@ -1,0 +1,16 @@
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+endpoint_snitch: SimpleSnitch
+
+# override via -Dcassandra.storage_port=7000
+storage_port: 7000
+# override via -Dcassandra.native_transport_port=9042
+native_transport_port: 9042
+listen_address: 127.0.0.1
+start_native_transport: true
+start_rpc: false
+seed_provider:
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      - seeds: "127.0.0.1"

--- a/jersey2-cassandra3/src/main/resources/log4j.properties
+++ b/jersey2-cassandra3/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} [%X{userName}] [%X{traceId}/%X{spanId}] %-5p [%t] %C{2} (%F:%L) - %m%n

--- a/jersey2-cassandra3/src/main/resources/tracing.xml
+++ b/jersey2-cassandra3/src/main/resources/tracing.xml
@@ -1,0 +1,89 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+
+  <!-- Configuration for how to send spans to Zipkin -->
+  <bean id="sender" class="zipkin2.reporter.beans.URLConnectionSenderFactoryBean">
+    <property name="endpoint" value="${zipkin.baseUrl:http://127.0.0.1:9411}/api/v2/spans"/>
+  </bean>
+
+  <!-- Configuration for how to buffer spans into messages for Zipkin -->
+  <bean id="zipkinSpanHandler" class="zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean">
+    <property name="sender" ref="sender"/>
+    <!-- wait up to half a second for any in-flight spans on close -->
+    <property name="closeTimeout" value="500"/>
+  </bean>
+
+  <!-- Defines a propagated field "userName" that uses the remote header "user_name" -->
+  <bean id="userNameBaggageField" class="brave.baggage.BaggageField" factory-method="create">
+    <constructor-arg value="userName"/>
+  </bean>
+  <bean id="propagationFactory" class="brave.spring.beans.BaggagePropagationFactoryBean">
+    <property name="configs">
+      <bean class="brave.spring.beans.SingleBaggageFieldFactoryBean">
+        <property name="field" ref="userNameBaggageField"/>
+        <property name="keyNames" value="user_name"/>
+      </bean>
+    </property>
+  </bean>
+
+  <!-- Allows log patterns to use %{traceId} %{spanId} and %{userName} -->
+  <bean id="correlationScopeDecorator"
+      class="brave.spring.beans.CorrelationScopeDecoratorFactoryBean">
+    <property name="builder">
+      <bean class="brave.context.slf4j.MDCScopeDecorator" factory-method="newBuilder"/>
+    </property>
+    <property name="configs">
+      <list>
+        <bean class="brave.spring.beans.SingleCorrelationFieldFactoryBean">
+          <property name="baggageField">
+            <util:constant static-field="brave.baggage.BaggageFields.TRACE_ID"/>
+          </property>
+        </bean>
+        <bean class="brave.spring.beans.SingleCorrelationFieldFactoryBean">
+          <property name="baggageField">
+            <util:constant static-field="brave.baggage.BaggageFields.SPAN_ID"/>
+          </property>
+        </bean>
+        <bean class="brave.spring.beans.SingleCorrelationFieldFactoryBean">
+          <property name="baggageField" ref="userNameBaggageField"/>
+        </bean>
+      </list>
+    </property>
+  </bean>
+
+  <!-- allows us to read the service name from spring config -->
+  <context:property-placeholder/>
+
+  <!-- Controls aspects of tracing such as the service name that shows up in the UI -->
+  <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
+    <property name="localServiceName" value="${brave.localServiceName}"/>
+    <property name="supportsJoin" value="${brave.supportsJoin:true}"/>
+    <property name="traceId128Bit" value="${brave.traceId128Bit:false}"/>
+    <property name="propagationFactory" ref="propagationFactory"/>
+    <property name="currentTraceContext">
+      <bean class="brave.spring.beans.CurrentTraceContextFactoryBean">
+        <property name="scopeDecorators" ref="correlationScopeDecorator"/>
+      </bean>
+    </property>
+    <property name="spanHandlers" ref="zipkinSpanHandler"/>
+  </bean>
+
+  <!-- Allows someone to add tags to a span if a trace is in progress, via SpanCustomizer -->
+  <bean id="spanCustomizer" class="brave.CurrentSpanCustomizer" factory-method="create">
+    <constructor-arg index="0" ref="tracing"/>
+  </bean>
+
+  <!-- Decides how to name and tag spans. By default they are named the same as the HTTP method. -->
+  <bean id="httpTracing" class="brave.spring.beans.HttpTracingFactoryBean">
+    <property name="tracing" ref="tracing"/>
+  </bean>
+</beans>


### PR DESCRIPTION
This adds an example named `jersey2-cassandra3`

Instead of servlet, the frontend is a Jersey application. The backend is Apache Cassandra 3.x.
Requests from the frontend to the backend are via [DataStax Java Driver](https://github.com/datastax/java-driver) 3.x.
Both services run as a normal Java application.

* `brave.example.Frontend` - HTTP controller and DataStax Java Driver
* `brave.example.Backend` - Sets system properties and runs `CassandraDaemon`

Here's an example screen shot:
![screen shot](https://user-images.githubusercontent.com/64215/100691758-581f8780-33c4-11eb-8451-2ad9c52a0e08.png)

Rationale are documented inside the jersey2-cassandra3 directory.