### PR TITLE
Ensures single-arch images aren't accidentally republishes as multi

### DIFF
--- a/build-bin/docker-compose.test.yml
+++ b/build-bin/docker-compose.test.yml
@@ -4,7 +4,7 @@ version: "2.4"
 services:
   sut:
     container_name: sut
-    image: ghcr.io/openzipkin/alpine:3.12.1
+    image: ghcr.io/openzipkin/alpine:3.12.3
     entrypoint: /bin/sh
     # Keep the container running until HEALTHCHECK passes
     command: "-c \"sleep 5m\""
@@ -16,7 +16,7 @@ services:
         condition: service_started
   get_frontend:
     container_name: get_frontend
-    image: ghcr.io/openzipkin/alpine:3.12.1
+    image: ghcr.io/openzipkin/alpine:3.12.3
     entrypoint: /bin/sh
     # Pass a trace header with a constant trace ID, so that we know what to look for later
     command: "-c \"wget -qO- --header 'b3: cafebabecafebabe-cafebabecafebabe-1' http://frontend:8081\""

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -25,7 +25,7 @@ if ! test -f ${docker_file}; then
 fi
 
 # Add default labels for the day and the SHA we're building from
-docker_args="-f ${docker_file} \
+docker_args="${DOCKER_ARGS:-} -f ${docker_file} \
 --label org.opencontainers.image.created=$(date +%Y-%m-%d) \
 --label org.opencontainers.image.revision=$(git rev-parse --short HEAD)"
 
@@ -48,13 +48,13 @@ fi
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
 # Ex. ghcr.io/openzipkin/java:15.0.1_p9-jre
 #
-# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.1
+# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
 # See https://docs.docker.com/glossary/#parent-image
 if [ -n "${DOCKER_PARENT_IMAGE}" ]; then
   docker_args="${docker_args} --build-arg docker_parent_image=${DOCKER_PARENT_IMAGE}"
 fi
 
-# When non-empty, becomes the build-arg alpine_version. Ex. "3.12.1"
+# When non-empty, becomes the build-arg alpine_version. Ex. "3.12.3"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/alpine
 if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -69,6 +69,7 @@ docker_archs=${DOCKER_ARCHS:-amd64 arm64}
 echo "Will build the following architectures: ${docker_archs}"
 
 docker_tag0="$(echo ${docker_tags} | awk '{print $1;}')"
+docker_arch0="$(echo ${docker_archs} | awk '{print $1;}')"
 arch_tags=""
 for docker_arch in ${docker_archs}; do
   arch_tag=${docker_image}:${docker_tag0}-${docker_arch}
@@ -79,24 +80,38 @@ done
 
 echo "Will push the following tags:\n${tags}"
 
-for tag in $(echo ${tags} | xargs); do
-  manifest_tags=""
-  for arch_tag in ${arch_tags}; do
-    docker_arch=$(echo ${arch_tag} | sed 's/.*-//g')
-    manifest_tag=${tag}-${docker_arch}
-    docker tag ${arch_tag} ${manifest_tag}
-    echo "Pushing tag ${manifest_tag}..."
-    docker push ${manifest_tag}
-    manifest_tags="${manifest_tags} ${manifest_tag}"
+if [ "${docker_arch0}" = "${docker_archs}" ]; then
+  # single architecture
+  arch_tag=${docker_image}:${docker_tag0}-${docker_arch0}
+
+  for tag in $(echo ${tags} | xargs); do
+    docker tag ${arch_tag} ${tag}
+    echo "Pushing tag ${tag}..."
+    docker push ${tag}
   done
 
-  docker manifest create ${tag} ${manifest_tags}
+else
+  # multi-architecture: make a manifest
+  for tag in $(echo ${tags} | xargs); do
+    manifest_tags=""
+    for arch_tag in ${arch_tags}; do
+      docker_arch=$(echo ${arch_tag} | sed 's/.*-//g')
+      manifest_tag=${tag}-${docker_arch}
+      docker tag ${arch_tag} ${manifest_tag}
+      echo "Pushing tag ${manifest_tag}..."
+      docker push ${manifest_tag}
+      manifest_tags="${manifest_tags} ${manifest_tag}"
+    done
 
-  for manifest_tag in ${manifest_tags}; do
-    docker_arch=$(echo ${manifest_tag} | sed 's/.*-//g')
-    docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
+    docker manifest create ${tag} ${manifest_tags}
+
+    for manifest_tag in ${manifest_tags}; do
+      docker_arch=$(echo ${manifest_tag} | sed 's/.*-//g')
+      docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
+    done
+
+    echo "Pushing manifest ${manifest_tag}..."
+    docker manifest push -p ${tag}
   done
+fi
 
-  echo "Pushing manifest ${manifest_tag}..."
-  docker manifest push -p ${tag}
-done

--- a/build-bin/docker_args
+++ b/build-bin/docker_args
@@ -14,12 +14,12 @@ DOCKER_PLATFORMS="linux/amd64,linux/arm64"
 
 case "${JRE_VERSION}" in
   6 )
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:6u119-6.22.0.3
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:1.6.0-119
     # single arch image
     DOCKER_PLATFORMS=linux/amd64
     ;;
   7 )
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:7u282-7.42.0.13
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:1.7.0_285
     # single arch image
     DOCKER_PLATFORMS=linux/amd64
     ;;


### PR DESCRIPTION
We had a problem where we exported images that had only one arch in
the parent layer as multi-platform. This fixes that.