### PR TITLE
ci: updates to latest docker scripts

### DIFF
--- a/.github/deploy-template.yml
+++ b/.github/deploy-template.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-{{VERSION}}-maven-${{ hashFiles('parent-pom.xml', '{{VERSION}}/pom.xml') }}

--- a/.github/deploy-template.yml
+++ b/.github/deploy-template.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-{{VERSION}}-maven-${{ hashFiles('parent-pom.xml', '{{VERSION}}/pom.xml') }}
           restore-keys: ${{ runner.os }}-{{VERSION}}-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy {{VERSION}}
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/test-template.yml
+++ b/.github/test-template.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-{{VERSION}}-maven-${{ hashFiles('parent-pom.xml', '{{VERSION}}/pom.xml') }}

--- a/.github/test-template.yml
+++ b/.github/test-template.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-{{VERSION}}-maven-${{ hashFiles('parent-pom.xml', '{{VERSION}}/pom.xml') }}
           restore-keys: ${{ runner.os }}-{{VERSION}}-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test {{VERSION}}
         run: |
           build-bin/configure_test {{VERSION}} &&

--- a/.github/workflows/deploy-armeria-kafka.yml
+++ b/.github/workflows/deploy-armeria-kafka.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-kafka-maven-${{ hashFiles('parent-pom.xml', 'armeria-kafka/pom.xml') }}

--- a/.github/workflows/deploy-armeria-kafka.yml
+++ b/.github/workflows/deploy-armeria-kafka.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-kafka-maven-${{ hashFiles('parent-pom.xml', 'armeria-kafka/pom.xml') }}
           restore-keys: ${{ runner.os }}-armeria-kafka-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy armeria-kafka
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-armeria.yml
+++ b/.github/workflows/deploy-armeria.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-maven-${{ hashFiles('parent-pom.xml', 'armeria/pom.xml') }}

--- a/.github/workflows/deploy-armeria.yml
+++ b/.github/workflows/deploy-armeria.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-maven-${{ hashFiles('parent-pom.xml', 'armeria/pom.xml') }}
           restore-keys: ${{ runner.os }}-armeria-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy armeria
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-dropwizard.yml
+++ b/.github/workflows/deploy-dropwizard.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-dropwizard-maven-${{ hashFiles('parent-pom.xml', 'dropwizard/pom.xml') }}
           restore-keys: ${{ runner.os }}-dropwizard-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy dropwizard
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-dropwizard.yml
+++ b/.github/workflows/deploy-dropwizard.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-dropwizard-maven-${{ hashFiles('parent-pom.xml', 'dropwizard/pom.xml') }}

--- a/.github/workflows/deploy-jersey2-cassandra3.yml
+++ b/.github/workflows/deploy-jersey2-cassandra3.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-jersey2-cassandra3-maven-${{ hashFiles('parent-pom.xml', 'jersey2-cassandra3/pom.xml') }}
           restore-keys: ${{ runner.os }}-jersey2-cassandra3-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy jersey2-cassandra3
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-jersey2-cassandra3.yml
+++ b/.github/workflows/deploy-jersey2-cassandra3.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-jersey2-cassandra3-maven-${{ hashFiles('parent-pom.xml', 'jersey2-cassandra3/pom.xml') }}

--- a/.github/workflows/deploy-netty4-grpc.yml
+++ b/.github/workflows/deploy-netty4-grpc.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-netty4-grpc-maven-${{ hashFiles('parent-pom.xml', 'netty4-grpc/pom.xml') }}
           restore-keys: ${{ runner.os }}-netty4-grpc-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy netty4-grpc
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-netty4-grpc.yml
+++ b/.github/workflows/deploy-netty4-grpc.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-netty4-grpc-maven-${{ hashFiles('parent-pom.xml', 'netty4-grpc/pom.xml') }}

--- a/.github/workflows/deploy-ratpack.yml
+++ b/.github/workflows/deploy-ratpack.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-ratpack-maven-${{ hashFiles('parent-pom.xml', 'ratpack/pom.xml') }}
           restore-keys: ${{ runner.os }}-ratpack-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy ratpack
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-ratpack.yml
+++ b/.github/workflows/deploy-ratpack.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-ratpack-maven-${{ hashFiles('parent-pom.xml', 'ratpack/pom.xml') }}

--- a/.github/workflows/deploy-webflux5-sleuth.yml
+++ b/.github/workflows/deploy-webflux5-sleuth.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux5-sleuth-maven-${{ hashFiles('parent-pom.xml', 'webflux5-sleuth/pom.xml') }}

--- a/.github/workflows/deploy-webflux5-sleuth.yml
+++ b/.github/workflows/deploy-webflux5-sleuth.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux5-sleuth-maven-${{ hashFiles('parent-pom.xml', 'webflux5-sleuth/pom.xml') }}
           restore-keys: ${{ runner.os }}-webflux5-sleuth-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy webflux5-sleuth
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-webmvc25-jetty.yml
+++ b/.github/workflows/deploy-webmvc25-jetty.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc25-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc25-jetty/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc25-jetty-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy webmvc25-jetty
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-webmvc25-jetty.yml
+++ b/.github/workflows/deploy-webmvc25-jetty.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc25-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc25-jetty/pom.xml') }}

--- a/.github/workflows/deploy-webmvc3-jetty.yml
+++ b/.github/workflows/deploy-webmvc3-jetty.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc3-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc3-jetty/pom.xml') }}

--- a/.github/workflows/deploy-webmvc3-jetty.yml
+++ b/.github/workflows/deploy-webmvc3-jetty.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc3-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc3-jetty/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc3-jetty-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy webmvc3-jetty
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-webmvc4-boot.yml
+++ b/.github/workflows/deploy-webmvc4-boot.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-boot-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-boot/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc4-boot-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy webmvc4-boot
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-webmvc4-boot.yml
+++ b/.github/workflows/deploy-webmvc4-boot.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-boot-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-boot/pom.xml') }}

--- a/.github/workflows/deploy-webmvc4-jetty.yml
+++ b/.github/workflows/deploy-webmvc4-jetty.yml
@@ -17,20 +17,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-jetty/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc4-jetty-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy webmvc4-jetty
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/deploy-webmvc4-jetty.yml
+++ b/.github/workflows/deploy-webmvc4-jetty.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-jetty/pom.xml') }}

--- a/.github/workflows/test-armeria-kafka.yml
+++ b/.github/workflows/test-armeria-kafka.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-kafka-maven-${{ hashFiles('parent-pom.xml', 'armeria-kafka/pom.xml') }}

--- a/.github/workflows/test-armeria-kafka.yml
+++ b/.github/workflows/test-armeria-kafka.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-kafka-maven-${{ hashFiles('parent-pom.xml', 'armeria-kafka/pom.xml') }}
           restore-keys: ${{ runner.os }}-armeria-kafka-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test armeria-kafka
         run: |
           build-bin/configure_test armeria-kafka &&

--- a/.github/workflows/test-armeria.yml
+++ b/.github/workflows/test-armeria.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-maven-${{ hashFiles('parent-pom.xml', 'armeria/pom.xml') }}
           restore-keys: ${{ runner.os }}-armeria-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test armeria
         run: |
           build-bin/configure_test armeria &&

--- a/.github/workflows/test-armeria.yml
+++ b/.github/workflows/test-armeria.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-maven-${{ hashFiles('parent-pom.xml', 'armeria/pom.xml') }}

--- a/.github/workflows/test-dropwizard.yml
+++ b/.github/workflows/test-dropwizard.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-dropwizard-maven-${{ hashFiles('parent-pom.xml', 'dropwizard/pom.xml') }}
           restore-keys: ${{ runner.os }}-dropwizard-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test dropwizard
         run: |
           build-bin/configure_test dropwizard &&

--- a/.github/workflows/test-dropwizard.yml
+++ b/.github/workflows/test-dropwizard.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-dropwizard-maven-${{ hashFiles('parent-pom.xml', 'dropwizard/pom.xml') }}

--- a/.github/workflows/test-jersey2-cassandra3.yml
+++ b/.github/workflows/test-jersey2-cassandra3.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-jersey2-cassandra3-maven-${{ hashFiles('parent-pom.xml', 'jersey2-cassandra3/pom.xml') }}

--- a/.github/workflows/test-jersey2-cassandra3.yml
+++ b/.github/workflows/test-jersey2-cassandra3.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-jersey2-cassandra3-maven-${{ hashFiles('parent-pom.xml', 'jersey2-cassandra3/pom.xml') }}
           restore-keys: ${{ runner.os }}-jersey2-cassandra3-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test jersey2-cassandra3
         run: |
           build-bin/configure_test jersey2-cassandra3 &&

--- a/.github/workflows/test-netty4-grpc.yml
+++ b/.github/workflows/test-netty4-grpc.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-netty4-grpc-maven-${{ hashFiles('parent-pom.xml', 'netty4-grpc/pom.xml') }}
           restore-keys: ${{ runner.os }}-netty4-grpc-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test netty4-grpc
         run: |
           build-bin/configure_test netty4-grpc &&

--- a/.github/workflows/test-netty4-grpc.yml
+++ b/.github/workflows/test-netty4-grpc.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-netty4-grpc-maven-${{ hashFiles('parent-pom.xml', 'netty4-grpc/pom.xml') }}

--- a/.github/workflows/test-ratpack.yml
+++ b/.github/workflows/test-ratpack.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-ratpack-maven-${{ hashFiles('parent-pom.xml', 'ratpack/pom.xml') }}
           restore-keys: ${{ runner.os }}-ratpack-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test ratpack
         run: |
           build-bin/configure_test ratpack &&

--- a/.github/workflows/test-ratpack.yml
+++ b/.github/workflows/test-ratpack.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-ratpack-maven-${{ hashFiles('parent-pom.xml', 'ratpack/pom.xml') }}

--- a/.github/workflows/test-webflux5-sleuth.yml
+++ b/.github/workflows/test-webflux5-sleuth.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux5-sleuth-maven-${{ hashFiles('parent-pom.xml', 'webflux5-sleuth/pom.xml') }}
           restore-keys: ${{ runner.os }}-webflux5-sleuth-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test webflux5-sleuth
         run: |
           build-bin/configure_test webflux5-sleuth &&

--- a/.github/workflows/test-webflux5-sleuth.yml
+++ b/.github/workflows/test-webflux5-sleuth.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux5-sleuth-maven-${{ hashFiles('parent-pom.xml', 'webflux5-sleuth/pom.xml') }}

--- a/.github/workflows/test-webmvc25-jetty.yml
+++ b/.github/workflows/test-webmvc25-jetty.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc25-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc25-jetty/pom.xml') }}

--- a/.github/workflows/test-webmvc25-jetty.yml
+++ b/.github/workflows/test-webmvc25-jetty.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc25-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc25-jetty/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc25-jetty-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test webmvc25-jetty
         run: |
           build-bin/configure_test webmvc25-jetty &&

--- a/.github/workflows/test-webmvc3-jetty.yml
+++ b/.github/workflows/test-webmvc3-jetty.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc3-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc3-jetty/pom.xml') }}

--- a/.github/workflows/test-webmvc3-jetty.yml
+++ b/.github/workflows/test-webmvc3-jetty.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc3-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc3-jetty/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc3-jetty-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test webmvc3-jetty
         run: |
           build-bin/configure_test webmvc3-jetty &&

--- a/.github/workflows/test-webmvc4-boot.yml
+++ b/.github/workflows/test-webmvc4-boot.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-boot-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-boot/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc4-boot-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test webmvc4-boot
         run: |
           build-bin/configure_test webmvc4-boot &&

--- a/.github/workflows/test-webmvc4-boot.yml
+++ b/.github/workflows/test-webmvc4-boot.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-boot-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-boot/pom.xml') }}

--- a/.github/workflows/test-webmvc4-jetty.yml
+++ b/.github/workflows/test-webmvc4-jetty.yml
@@ -16,20 +16,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-jetty/pom.xml') }}
           restore-keys: ${{ runner.os }}-webmvc4-jetty-maven-
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test webmvc4-jetty
         run: |
           build-bin/configure_test webmvc4-jetty &&

--- a/.github/workflows/test-webmvc4-jetty.yml
+++ b/.github/workflows/test-webmvc4-jetty.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-jetty/pom.xml') }}

--- a/build-bin/docker/docker-healthcheck
+++ b/build-bin/docker/docker-healthcheck
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2013-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -48,13 +48,13 @@ fi
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
 # e.g. ghcr.io/openzipkin/java:21.0.1_p12-jre
 #
-# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.18.5
+# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
 # See https://docs.docker.com/glossary/#parent-image
 if [ -n "${DOCKER_PARENT_IMAGE}" ]; then
   docker_args="${docker_args} --build-arg docker_parent_image=${DOCKER_PARENT_IMAGE}"
 fi
 
-# When non-empty, becomes the build-arg alpine_version. e.g. "3.18.5"
+# When non-empty, becomes the build-arg alpine_version. e.g. "3.12.3"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/alpine
 if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"

--- a/build-bin/docker/docker_block_on_health
+++ b/build-bin/docker/docker_block_on_health
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2013-2020 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -19,5 +19,10 @@ docker_tag=${1?full docker_tag is required. Ex openzipkin/zipkin:test}
 version=${2:-}
 docker_args=$($(dirname "$0")/docker_args ${version})
 
+# We don't need build kit, but Docker 20.10 no longer accepts --platform
+# without it. It is simpler to always enable it vs require maintainers to use
+# alternate OCI tools. See https://github.com/moby/moby/issues/41552
+export DOCKER_BUILDKIT=1
+
 echo "Building image ${docker_tag}"
-DOCKER_BUILDKIT=1 docker build --network=host --pull ${docker_args} --tag ${docker_tag} .
+docker build --network=host --pull ${docker_args} --tag ${docker_tag} .

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -27,6 +27,10 @@ set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
+
+# We don't need build kit, but Docker 20.10 no longer accepts --platform
+# without it. It is simpler to always enable it vs require maintainers to use
+# alternate OCI tools. See https://github.com/moby/moby/issues/41552
 export DOCKER_BUILDKIT=1
 
 case ${version} in

--- a/build-bin/docker/docker_test_image
+++ b/build-bin/docker/docker_test_image
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2013-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Updates template to use latest ubuntu LTS and actions versions, as well copies in comments about why not cache ~/.docker

Applies templates via `./.github/generate_workflows`