### PR TITLE
armeria: showcase Eureka integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Here are the example projects you can try:
   * Runtime: Armeria, SLF4J 1.7, JRE 21
   * Trace Instrumentation: [Armeria](https://armeria.dev/), [SLF4J](https://github.com/openzipkin/brave/tree/master/context/slf4j)
   * Trace Configuration: [Brave API](https://github.com/openzipkin/brave/tree/master/brave#setup) [Java](armeria/src/main/java/brave/example/HttpTracingFactory.java)
+  * You can also use Eureka discovery like this:
+    * `BRAVE_EXAMPLE=armeria docker-compose -f docker-compose.yml -f docker-compose-eureka.yml up`
 
 * [armeria-kafka](armeria-kafka) `BRAVE_EXAMPLE=armeria-kafka docker-compose -f docker-compose.yml -f docker-compose-kafka.yml up`
   * Runtime: Armeria, Kafka Clients and Streams 2.7, SLF4J 1.7, JRE 21

--- a/armeria/pom.xml
+++ b/armeria/pom.xml
@@ -24,12 +24,64 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.linecorp.armeria</groupId>
+      <artifactId>armeria</artifactId>
+      <exclusions>
+        <!-- temporary until netty includes https://github.com/netty/netty/pull/13724 -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- temporary until netty includes https://github.com/netty/netty/pull/13724 -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>linux-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>osx-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>osx-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>windows-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Instruments the underlying Armeria requests -->
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
       <artifactId>armeria-brave</artifactId>
     </dependency>
-
+    <!-- Optionally look up Zipkin with Eureka -->
+    <dependency>
+      <groupId>com.linecorp.armeria</groupId>
+      <artifactId>armeria-eureka</artifactId>
+    </dependency>
     <!-- Integrates so you can use log patterns like %X{traceId}/%X{spanId} -->
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
@@ -44,10 +96,6 @@
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-reporter-brave</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin.reporter2</groupId>
-      <artifactId>zipkin-sender-urlconnection</artifactId>
     </dependency>
   </dependencies>
 

--- a/armeria/src/main/java/brave/example/WebClientSender.java
+++ b/armeria/src/main/java/brave/example/WebClientSender.java
@@ -1,0 +1,48 @@
+package brave.example;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.MediaType;
+import java.io.IOException;
+import java.util.List;
+import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.Encoding;
+
+final class WebClientSender extends BytesMessageSender.Base {
+  final WebClient zipkinApiV2SpansClient;
+  volatile boolean closeCalled; // volatile as not called from the reporting thread.
+
+  WebClientSender(WebClient zipkinApiV2SpansClient) {
+    super(Encoding.JSON);
+    this.zipkinApiV2SpansClient = zipkinApiV2SpansClient;
+  }
+
+  @Override public int messageMaxBytes() {
+    return 500_000; // Use the most common HTTP default
+  }
+
+  @Override public void send(List<byte[]> encodedSpans) throws IOException {
+    if (closeCalled) throw new ClosedSenderException();
+    byte[] body = BytesMessageEncoder.JSON.encode(encodedSpans);
+    HttpRequest request =
+        HttpRequest.of(HttpMethod.POST, "", MediaType.JSON, HttpData.wrap(body));
+    AggregatedHttpResponse response = zipkinApiV2SpansClient.blocking().execute(request);
+    try (HttpData content = response.content()) {
+      if (!response.status().isSuccess()) {
+        if (content.isEmpty()) {
+          throw new IOException("response failed: " + response);
+        }
+        throw new IOException("response failed: " + content.toStringAscii());
+      }
+    }
+  }
+
+  @Override public void close() {
+    closeCalled = true;
+  }
+}

--- a/docker-compose-eureka.yml
+++ b/docker-compose-eureka.yml
@@ -1,0 +1,41 @@
+# permit depends_on/condition: service_healthy
+version: '2.4'
+
+services:
+  eureka:
+    image: ghcr.io/openzipkin/zipkin-eureka
+    container_name: eureka
+    # Uncomment to expose the eureka port for testing
+    #    ports:
+    #      - 8761:8761
+
+  zipkin:
+    extends:
+      file: docker-compose.yml
+      service: zipkin
+    environment:
+      - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
+      - EUREKA_HOSTNAME=zipkin
+    depends_on:
+      eureka:
+        condition: service_healthy
+
+  frontend:
+    extends:
+      file: docker-compose.yml
+      service: frontend
+    environment:
+      - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
+    depends_on:
+      eureka:
+        condition: service_healthy
+        
+  backend:
+    extends:
+      file: docker-compose.yml
+      service: backend
+    environment:
+      - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
+    depends_on:
+      eureka:
+        condition: service_healthy

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,7 +1,6 @@
 ---
-# Format version 2.1 was introduced with Docker Compose v1.9
-# We need Docker Compose v1.9+ for unset variable interpolation
-version: "2.1"
+# permit depends_on/condition: service_healthy
+version: "2.4"
 
 services:
   kafka:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
-# Format version 2.1 was introduced with Docker Compose v1.9
-# We need Docker Compose v1.9+ for unset variable interpolation
-version: "2.1"
+# permit depends_on/condition: service_healthy
+version: "2.4"
 
 # BRAVE_EXAMPLE choices are listed here https://github.com/openzipkin/brave-example#example-projects
 
@@ -16,7 +15,7 @@ services:
       backend:
         condition: service_healthy
       zipkin:
-        condition: service_started
+        condition: service_healthy
   # Serves the /api endpoint the frontend uses
   backend:
     container_name: backend
@@ -24,7 +23,7 @@ services:
     entrypoint: start-backend
     depends_on:
       zipkin:
-        condition: service_started
+        condition: service_healthy
   # View traces at http://127.0.0.1:9411/zipkin
   zipkin:
     image: ghcr.io/openzipkin/zipkin-slim

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -34,7 +34,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <brave.version>6.0.0</brave.version>
-    <zipkin-reporter.version>3.2.0</zipkin-reporter.version>
+    <zipkin-reporter.version>3.2.1</zipkin-reporter.version>
 
     <!-- The JRE used in Docker images can be higher than ${maven.compiler.release}. -->
     <jre.version>SET MANUALLY IN PROJECTS</jre.version>

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -34,7 +34,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <brave.version>6.0.0</brave.version>
-    <zipkin-reporter.version>3.1.1</zipkin-reporter.version>
+    <zipkin-reporter.version>3.2.0</zipkin-reporter.version>
 
     <!-- The JRE used in Docker images can be higher than ${maven.compiler.release}. -->
     <jre.version>SET MANUALLY IN PROJECTS</jre.version>


### PR DESCRIPTION
Note: If you don't set zipkin's `EUREKA_HOSTNAME=zipkin` then clients will crash hard like this. It may be something to fix in armeria, or maybe we should require explicit setting. 

```bash
$ build-bin/docker/docker_build openzipkin/brave-example:armeria-test
--snip--
$  docker-compose -f docker-compose.yml -f docker-compose-eureka.yml up
--snip--
backend   | 08:01:00.115 [armeria-common-worker-epoll-2-2] [] [/] WARN  c.l.a.c.eureka.EurekaEndpointGroup - Unexpected exception while parsing a response from: http://eureka:8761/eureka/v2. (content: {"application":{"name":"ZIPKIN","instance":[{"instanceId":"08d1cd941327:zipkin:9411","hostName":"08d1cd941327","app":"ZIPKIN","ipAddr":"172.21.0.3","status":"UP","overriddenStatus":"UNKNOWN","port":{"$":9411,"@enabled":"true"},"securePort":{"$":0,"@enabled":"false"},"countryId":1,"dataCenterInfo":{"@class":"com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo","name":"MyOwn"},"leaseInfo":{"renewalIntervalInSecs":30,"durationInSecs":90,"registrationTimestamp":1705219255654,"lastRenewalTimestamp":1705219255654,"evictionTimestamp":0,"serviceUpTimestamp":1705219255086},"metadata":{"@class":"java.util.Collections$EmptyMap"},"healthCheckUrl":"http://172.21.0.3:9411/health","vipAddress":"08d1cd941327:9411","isCoordinatingDiscoveryServer":"false","lastUpdatedTimestamp":"1705219255654","lastDirtyTimestamp":"1705219254880","actionType":"ADDED"}]}}, responseConverter: com.linecorp.armeria.client.eureka.EurekaEndpointGroup$ApplicationConverter@7d7d125f, requestHeaders: [:method=GET, :path=/apps/zipkin, accept=application/json; charset=utf-8])
backend   | java.lang.IllegalArgumentException: Not a valid domain name: '08d1cd941327'
backend   | 	at com.linecorp.armeria.internal.shaded.guava.base.Preconditions.checkArgument(Preconditions.java:218)
backend   | 	at com.linecorp.armeria.internal.shaded.guava.net.InternetDomainName.<init>(InternetDomainName.java:162)
backend   | 	at com.linecorp.armeria.internal.shaded.guava.net.InternetDomainName.from(InternetDomainName.java:252)
backend   | 	at com.linecorp.armeria.client.Endpoint.normalizeHost(Endpoint.java:222)
backend   | 	at com.linecorp.armeria.client.Endpoint.create(Endpoint.java:207)
backend   | 	at com.linecorp.armeria.client.Endpoint.of(Endpoint.java:133)
backend   | 	at com.linecorp.armeria.client.eureka.EurekaEndpointGroup.endpoint(EurekaEndpointGroup.java:412)
backend   | 	at com.linecorp.armeria.client.eureka.EurekaEndpointGroup.lambda$endpoints$8(EurekaEndpointGroup.java:362)
```