### PR TITLE
armeria: adds access logger integration

### DIFF
--- a/armeria/src/main/java/brave/example/Backend.java
+++ b/armeria/src/main/java/brave/example/Backend.java
@@ -5,6 +5,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.brave.BraveService;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
 import java.util.Date;
 
@@ -13,8 +14,12 @@ public final class Backend {
   public static void main(String[] args) {
     final HttpTracing httpTracing = HttpTracingFactory.create("backend");
 
+    final AccessLogWriter accessLogWriter =
+        HttpTracingFactory.accessLogWriter(httpTracing, AccessLogWriter.common());
+
     final Server server = Server.builder()
         .http(9000)
+        .accessLogWriter(accessLogWriter, true)
         .service("/health", HealthCheckService.builder().build())
         .service("/api", (ctx, req) -> {
           String response = new Date().toString();

--- a/armeria/src/main/resources/logback.xml
+++ b/armeria/src/main/resources/logback.xml
@@ -8,7 +8,18 @@
     </encoder>
   </appender>
 
-  <logger name="com.linecorp.armeria" level="info"/>
+  <appender name="ACCESS" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%X{traceId}/%X{spanId}] %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.linecorp.armeria.logging.access" level="info" additivity="false">
+    <appender-ref ref="ACCESS"/>
+  </logger>
+
+  <logger name="com.linecorp.armeria" level="warn"/>
+  <logger name="com.linecorp.armeria.server.Server" level="info"/>
 
   <root level="info">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
I think this setup isn't necessarily intuitive, so needs consideration if something to do by default or not.

```
zipkin    | 2024-02-20 01:23:48:341 [armeria-boss-http-*:9411] INFO Server - Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
backend   | 01:23:52.939 [main] [] [/] INFO  brave.example.HttpTracingFactory - Using zipkin URI: http://zipkin:9411//api/v2/spans
backend   | 01:23:53.367 [armeria-boss-http-*:9000] [] [/] INFO  com.linecorp.armeria.server.Server - Serving HTTP at /0.0.0.0:9000 - http://127.0.0.1:9000/
frontend  | 01:23:54.573 [main] [] [/] INFO  brave.example.HttpTracingFactory - Using zipkin URI: http://zipkin:9411//api/v2/spans
frontend  | 01:23:55.042 [armeria-boss-http-*:8081] [] [/] INFO  com.linecorp.armeria.server.Server - Serving HTTP at /0.0.0.0:8081 - http://127.0.0.1:8081/
frontend  | [84add10fbf6ccd88/84add10fbf6ccd88] 172.29.0.1 - - 20/Feb/2024:01:23:59 +0000 "GET /#Frontend$$Lambda/0x0000000100334120 h1c" 200 28
backend   | [84add10fbf6ccd88/0c65e000e3889b86] 172.29.0.4 - - 20/Feb/2024:01:23:59 +0000 "GET /api#Backend$$Lambda/0x0000000100330968 h2c" 200 28
```