### PR TITLE
Allows overriding the BACKEND_ENDPOINT via env

### DIFF
--- a/armeria/src/main/java/brave/example/Frontend.java
+++ b/armeria/src/main/java/brave/example/Frontend.java
@@ -8,14 +8,21 @@ import com.linecorp.armeria.server.brave.BraveService;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class Frontend {
+  static final Logger LOGGER = LoggerFactory.getLogger(HttpTracingFactory.class);
 
   public static void main(String[] args) {
     final HttpTracing httpTracing = HttpTracingFactory.create("frontend");
 
+    final String backendEndpoint =
+        System.getProperty("backend.endpoint", "http://127.0.0.1:9000/api");
+    LOGGER.info("Using backend endpoint: {}", backendEndpoint);
+
     final WebClient backendClient =
-        WebClient.builder(System.getProperty("backend.endpoint", "http://127.0.0.1:9000/api"))
+        WebClient.builder(backendEndpoint)
             .decorator(BraveClient.newDecorator(httpTracing.clientOf("backend")))
             .build();
 

--- a/armeria/src/main/java/brave/example/Frontend.java
+++ b/armeria/src/main/java/brave/example/Frontend.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class Frontend {
-  static final Logger LOGGER = LoggerFactory.getLogger(HttpTracingFactory.class);
+  static final Logger LOGGER = LoggerFactory.getLogger(Frontend.class);
 
   public static void main(String[] args) {
     final HttpTracing httpTracing = HttpTracingFactory.create("frontend");

--- a/docker/bin/install-example
+++ b/docker/bin/install-example
@@ -28,19 +28,23 @@ tee -a start-frontend start-backend <<-'EOF'
 export IP="$(hostname -i || echo '127.0.0.1')"
 EOF
 
+# Declare variables that expand variables set in this shell script/
+# These don't need to be exported as they are converted to java properties.
 cat >> start-frontend <<-EOF
-export PORT=${frontend_port}
-export EXAMPLE=${version}
-export EXAMPLE_SERVICE=frontend
+PORT=${frontend_port}
+EXAMPLE=${version}
+EXAMPLE_SERVICE=frontend
+DEFAULT_BACKEND_ENDPOINT=http://backend:${backend_port}/api
 EOF
 
 cat >> start-backend <<-EOF
-export PORT=${backend_port}
-export EXAMPLE=${version}
-export EXAMPLE_SERVICE=backend
+PORT=${backend_port}
+EXAMPLE=${version}
+EXAMPLE_SERVICE=backend
 EOF
 
-# Add common elements for Java applications
+# Add common elements for Java applications.
+# HEALTHCHECK variables need to be exported as they are read via proc info.
 tee -a start-frontend start-backend <<-'EOF'
 export HEALTHCHECK_IP=${IP}
 export HEALTHCHECK_PORT=${PORT}
@@ -55,7 +59,8 @@ exec java ${JAVA_OPTS} -cp 'classes:lib/*' \
 -Dzipkin.baseUrl=${ZIPKIN_BASEURL:-http://zipkin:9411/} \
 EOF
 
-echo "-Dbackend.endpoint=http://backend:${backend_port}/api \\" >> start-frontend
+# Allow override of the backend endpoint, for a multi-container pod.
+echo '-Dbackend.endpoint=${BACKEND_ENDPOINT:-${DEFAULT_BACKEND_ENDPOINT}} \' >> start-frontend
 
 # Add the main class
 echo 'brave.example.Frontend "$@"' >> start-frontend

--- a/docker/bin/install-example
+++ b/docker/bin/install-example
@@ -28,19 +28,18 @@ tee -a start-frontend start-backend <<-'EOF'
 export IP="$(hostname -i || echo '127.0.0.1')"
 EOF
 
-# Declare variables that expand variables set in this shell script/
-# These don't need to be exported as they are converted to java properties.
+# Declare variables that expand variables set in this shell script.
 cat >> start-frontend <<-EOF
-PORT=${frontend_port}
-EXAMPLE=${version}
-EXAMPLE_SERVICE=frontend
+export PORT=${frontend_port}
+export EXAMPLE=${version}
+export EXAMPLE_SERVICE=frontend
 DEFAULT_BACKEND_ENDPOINT=http://backend:${backend_port}/api
 EOF
 
 cat >> start-backend <<-EOF
-PORT=${backend_port}
-EXAMPLE=${version}
-EXAMPLE_SERVICE=backend
+export PORT=${backend_port}
+export EXAMPLE=${version}
+export EXAMPLE_SERVICE=backend
 EOF
 
 # Add common elements for Java applications.

--- a/docker/bin/post-install-example-cassandra
+++ b/docker/bin/post-install-example-cassandra
@@ -5,7 +5,7 @@ set -eux
 sed -i 's~JAVA_OPTS=~sed -i "s/127.0.0.1/$IP/g" classes/cassandra.yaml\n\nJAVA_OPTS=~' start-backend
 
 # Communication isn't HTTP
-sed -i 's~endpoint=http://\(.*\)/api~contactPoint=\1~' start-frontend
+sed -i 's~DEFAULT_BACKEND_ENDPOINT=http://\(.*\)/api~DEFAULT_BACKEND_ENDPOINT=\1~' start-frontend
 sed -i 's/HEALTHCHECK_KIND=http/HEALTHCHECK_KIND=tcp/g' start-backend
 
 # Cassandra needs more than 32m memory

--- a/jersey2-cassandra3/src/main/java/brave/example/Frontend.java
+++ b/jersey2-cassandra3/src/main/java/brave/example/Frontend.java
@@ -15,10 +15,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.RuntimeDelegate;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class Frontend {
+  static final Logger LOGGER = LoggerFactory.getLogger(Frontend.class);
+
   @Path("")
   public static class Resource {
     final Session session;
@@ -52,6 +56,8 @@ public final class Frontend {
   public static void main(String[] args) throws Exception {
     String contactPointString = System.getProperty("backend.endpoint", "127.0.0.1:9042");
     HostAndPort parsed = HostAndPort.fromString(contactPointString).withDefaultPort(9042);
+    LOGGER.info("Using contact point: {}", parsed);
+
     Cluster cluster = Cluster.builder()
         .addContactPointsWithPorts(new InetSocketAddress(parsed.getHost(), parsed.getPort()))
         .build();

--- a/jersey2-cassandra3/src/main/java/brave/example/Frontend.java
+++ b/jersey2-cassandra3/src/main/java/brave/example/Frontend.java
@@ -50,7 +50,7 @@ public final class Frontend {
   }
 
   public static void main(String[] args) throws Exception {
-    String contactPointString = System.getProperty("backend.contactPoint", "127.0.0.1:9042");
+    String contactPointString = System.getProperty("backend.endpoint", "127.0.0.1:9042");
     HostAndPort parsed = HostAndPort.fromString(contactPointString).withDefaultPort(9042);
     Cluster cluster = Cluster.builder()
         .addContactPointsWithPorts(new InetSocketAddress(parsed.getHost(), parsed.getPort()))


### PR DESCRIPTION
The default docker image sets the backend endpoint to "http://backend:9000/api", which is fine for normal docker.

However, when frontend is in the same k8s pod as backend, it needs to refer to it by localhost. This is because within a pod, containers communicate by localhost despite being defined in different docker containers. In other words, it is similar to laptop where you have to mind your ports.

See https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking

This adds support for overriding via `BACKEND_ENDPOINT`, which would be "http://localhost:9000/api" in a k8s "extra container' in the same pod. Literally, [zipkin-helm](https://github.com/openzipkin/zipkin-helm) will use this to support integration tests via "helm test".
