### PR TITLE
license: removes copyright year and uses SPDX ID

### DIFF
--- a/.github/deploy-template.yml
+++ b/.github/deploy-template.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/test-template.yml
+++ b/.github/test-template.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-armeria-kafka.yml
+++ b/.github/workflows/deploy-armeria-kafka.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-armeria.yml
+++ b/.github/workflows/deploy-armeria.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-jersey2-cassandra3.yml
+++ b/.github/workflows/deploy-jersey2-cassandra3.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-netty4-grpc.yml
+++ b/.github/workflows/deploy-netty4-grpc.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-webflux5-sleuth.yml
+++ b/.github/workflows/deploy-webflux5-sleuth.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-webflux6-micrometer.yml
+++ b/.github/workflows/deploy-webflux6-micrometer.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-webmvc25-jetty.yml
+++ b/.github/workflows/deploy-webmvc25-jetty.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-webmvc3-jetty.yml
+++ b/.github/workflows/deploy-webmvc3-jetty.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-webmvc4-boot.yml
+++ b/.github/workflows/deploy-webmvc4-boot.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-webmvc4-jetty.yml
+++ b/.github/workflows/deploy-webmvc4-jetty.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-armeria-kafka.yml
+++ b/.github/workflows/test-armeria-kafka.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-armeria.yml
+++ b/.github/workflows/test-armeria.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-jersey2-cassandra3.yml
+++ b/.github/workflows/test-jersey2-cassandra3.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-netty4-grpc.yml
+++ b/.github/workflows/test-netty4-grpc.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-webflux5-sleuth.yml
+++ b/.github/workflows/test-webflux5-sleuth.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-webflux6-micrometer.yml
+++ b/.github/workflows/test-webflux6-micrometer.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-webmvc25-jetty.yml
+++ b/.github/workflows/test-webmvc25-jetty.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-webmvc3-jetty.yml
+++ b/.github/workflows/test-webmvc3-jetty.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-webmvc4-boot.yml
+++ b/.github/workflows/test-webmvc4-boot.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test-webmvc4-jetty.yml
+++ b/.github/workflows/test-webmvc4-jetty.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -82,8 +82,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full git history for license check
       - name: Test
         run: |
           build-bin/configure_test
@@ -124,8 +122,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1  # only needed to get the sha label
       - name: Configure Deploy
         run: build-bin/configure_deploy
         env:

--- a/build-bin/docker/configure_docker
+++ b/build-bin/docker/configure_docker
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Defends against build outages caused by Docker Hub (docker.io) pull rate limits.

--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Ensures Docker is logged in and it can build multi-architecture.

--- a/build-bin/docker/docker-healthcheck
+++ b/build-bin/docker/docker-healthcheck
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # HEALTHCHECK for use in `docker ps`, `docker-compose ps`, or a readiness probe in k8s.

--- a/build-bin/docker/docker_arch
+++ b/build-bin/docker/docker_arch
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script gets a normalized name for the architecture as used in Docker. This will be a subset

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This builds common docker arguments used by docker_build and docker_push.

--- a/build-bin/docker/docker_block_on_health
+++ b/build-bin/docker/docker_block_on_health
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Blocks until a named docker container with a valid HEALTHCHECK instruction is healthy or not:

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script pushes images to GitHub Container Registry (ghcr.io).

--- a/build-bin/docker/docker_test_image
+++ b/build-bin/docker/docker_test_image
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Tests a an image by awaiting its HEALTHCHECK.

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/maven/maven_go_offline
+++ b/build-bin/maven/maven_go_offline
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This is a go-offline that properly works with multi-module builds

--- a/build-bin/maven/maven_opts
+++ b/build-bin/maven/maven_opts
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script checks each variable value, so it isn't important to fail on unbound (set -u)

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script gets one jar from Maven, most typically an exec or module jar, extracting its contents


### PR DESCRIPTION
This project wasn't using the license plugin, but had some copy-paste license that should be coherent with other projects. Similarly, we don't need to specify default fetch-depth on checkout.

See https://github.com/openzipkin/zipkin-reporter-java/pull/257