### PR TITLE
Moves github actions to latest Ubuntu LTS 24.04

### DIFF
--- a/.github/deploy-template.yml
+++ b/.github/deploy-template.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-{{VERSION}}-maven-${{ hashFiles('parent-pom.xml', '{{VERSION}}/pom.xml') }}

--- a/.github/test-template.yml
+++ b/.github/test-template.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-{{VERSION}}-maven-${{ hashFiles('parent-pom.xml', '{{VERSION}}/pom.xml') }}

--- a/.github/workflows/deploy-armeria-kafka.yml
+++ b/.github/workflows/deploy-armeria-kafka.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-kafka-maven-${{ hashFiles('parent-pom.xml', 'armeria-kafka/pom.xml') }}

--- a/.github/workflows/deploy-armeria.yml
+++ b/.github/workflows/deploy-armeria.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-maven-${{ hashFiles('parent-pom.xml', 'armeria/pom.xml') }}

--- a/.github/workflows/deploy-jersey2-cassandra3.yml
+++ b/.github/workflows/deploy-jersey2-cassandra3.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-jersey2-cassandra3-maven-${{ hashFiles('parent-pom.xml', 'jersey2-cassandra3/pom.xml') }}

--- a/.github/workflows/deploy-netty4-grpc.yml
+++ b/.github/workflows/deploy-netty4-grpc.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-netty4-grpc-maven-${{ hashFiles('parent-pom.xml', 'netty4-grpc/pom.xml') }}

--- a/.github/workflows/deploy-webflux5-sleuth.yml
+++ b/.github/workflows/deploy-webflux5-sleuth.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux5-sleuth-maven-${{ hashFiles('parent-pom.xml', 'webflux5-sleuth/pom.xml') }}

--- a/.github/workflows/deploy-webflux6-micrometer.yml
+++ b/.github/workflows/deploy-webflux6-micrometer.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux6-micrometer-maven-${{ hashFiles('parent-pom.xml', 'webflux6-micrometer/pom.xml') }}

--- a/.github/workflows/deploy-webmvc25-jetty.yml
+++ b/.github/workflows/deploy-webmvc25-jetty.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc25-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc25-jetty/pom.xml') }}

--- a/.github/workflows/deploy-webmvc3-jetty.yml
+++ b/.github/workflows/deploy-webmvc3-jetty.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc3-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc3-jetty/pom.xml') }}

--- a/.github/workflows/deploy-webmvc4-boot.yml
+++ b/.github/workflows/deploy-webmvc4-boot.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-boot-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-boot/pom.xml') }}

--- a/.github/workflows/deploy-webmvc4-jetty.yml
+++ b/.github/workflows/deploy-webmvc4-jetty.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-jetty/pom.xml') }}

--- a/.github/workflows/test-armeria-kafka.yml
+++ b/.github/workflows/test-armeria-kafka.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-kafka-maven-${{ hashFiles('parent-pom.xml', 'armeria-kafka/pom.xml') }}

--- a/.github/workflows/test-armeria.yml
+++ b/.github/workflows/test-armeria.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-armeria-maven-${{ hashFiles('parent-pom.xml', 'armeria/pom.xml') }}

--- a/.github/workflows/test-jersey2-cassandra3.yml
+++ b/.github/workflows/test-jersey2-cassandra3.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-jersey2-cassandra3-maven-${{ hashFiles('parent-pom.xml', 'jersey2-cassandra3/pom.xml') }}

--- a/.github/workflows/test-netty4-grpc.yml
+++ b/.github/workflows/test-netty4-grpc.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-netty4-grpc-maven-${{ hashFiles('parent-pom.xml', 'netty4-grpc/pom.xml') }}

--- a/.github/workflows/test-webflux5-sleuth.yml
+++ b/.github/workflows/test-webflux5-sleuth.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux5-sleuth-maven-${{ hashFiles('parent-pom.xml', 'webflux5-sleuth/pom.xml') }}

--- a/.github/workflows/test-webflux6-micrometer.yml
+++ b/.github/workflows/test-webflux6-micrometer.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webflux6-micrometer-maven-${{ hashFiles('parent-pom.xml', 'webflux6-micrometer/pom.xml') }}

--- a/.github/workflows/test-webmvc25-jetty.yml
+++ b/.github/workflows/test-webmvc25-jetty.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc25-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc25-jetty/pom.xml') }}

--- a/.github/workflows/test-webmvc3-jetty.yml
+++ b/.github/workflows/test-webmvc3-jetty.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc3-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc3-jetty/pom.xml') }}

--- a/.github/workflows/test-webmvc4-boot.yml
+++ b/.github/workflows/test-webmvc4-boot.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-boot-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-boot/pom.xml') }}

--- a/.github/workflows/test-webmvc4-jetty.yml
+++ b/.github/workflows/test-webmvc4-jetty.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./m2repository  # Shared with the Docker build context via .dockerignore
           key: ${{ runner.os }}-webmvc4-jetty-maven-${{ hashFiles('parent-pom.xml', 'webmvc4-jetty/pom.xml') }}

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -47,7 +47,7 @@
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
     <maven-help-plugin.version>3.4.1</maven-help-plugin.version>
-    <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
   </properties>
 


### PR DESCRIPTION
also to actions/cache@v4 and a patch bump of one out-of-date maven plugin
 (maven-jar-plugin 3.4.1->3.4.2)