### PR TITLE
Updates to latest maven versions aligned with latest docker images

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,5 +16,5 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/build-bin/docker-compose.base.yml
+++ b/build-bin/docker-compose.base.yml
@@ -7,7 +7,7 @@ version: "2.4"
 services:
   sut:
     container_name: sut
-    image: ghcr.io/openzipkin/alpine:3.20.2
+    image: ghcr.io/openzipkin/alpine:3.20.3
     entrypoint: /bin/sh
     # Keep the container running until HEALTHCHECK passes
     command: "-c \"sleep 5m\""
@@ -16,7 +16,7 @@ services:
       test: wget -qO- --spider http://zipkin:9411/api/v2/trace/cafebabecafebabe
   get_frontend:
     container_name: get_frontend
-    image: ghcr.io/openzipkin/alpine:3.20.2
+    image: ghcr.io/openzipkin/alpine:3.20.3
     entrypoint: /bin/sh
     # Pass a trace header with a constant trace ID, so that we know what to look for later
     command: "-c \"wget -qO- --header 'b3: cafebabecafebabe-cafebabecafebabe-1' http://frontend:8081\""

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -37,7 +37,7 @@ if [ -n "${DOCKER_TARGET}" ]; then
 fi
 
 # When non-empty, becomes the layer that builds the maven projects.
-# e.g. ghcr.io/openzipkin/java:11.0.24_p8
+# e.g. ghcr.io/openzipkin/java:11.0.25_p9
 #
 # This must include maven and a full JDK.
 if [ -n "${DOCKER_BUILD_IMAGE}" ]; then
@@ -45,7 +45,7 @@ if [ -n "${DOCKER_BUILD_IMAGE}" ]; then
 fi
 
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
-# e.g. ghcr.io/openzipkin/java:21.0.4_p7-jre
+# e.g. ghcr.io/openzipkin/java:21.0.5_p11-jre
 #
 # This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
 # See https://docs.docker.com/glossary/#parent-image
@@ -59,7 +59,7 @@ if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"
 fi
 
-# When non-empty, becomes the build-arg java_version. e.g. "21.0.4_p7"
+# When non-empty, becomes the build-arg java_version. e.g. "21.0.5_p11"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/java
 if [ -n "${JAVA_VERSION}" ]; then
   docker_args="${docker_args} --build-arg java_version=${JAVA_VERSION}"

--- a/build-bin/docker_args
+++ b/build-bin/docker_args
@@ -8,38 +8,38 @@ else
   exit 1
 fi
 
-JAVA_VERSION=${JAVA_VERSION:-21.0.4_p7}
+JAVA_VERSION=${JAVA_VERSION:-21.0.5_p11}
 # DOCKER_ARCHS to eventually push to the registry
 DOCKER_ARCHS="amd64 arm64"
 
 case "${JRE_VERSION}" in
   6 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.24_p8
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
     DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:1.6.0-119
     # single arch image
     DOCKER_ARCHS=amd64
     ;;
   7 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.24_p8
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
     DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:1.7.0_352
     # single arch image
     DOCKER_ARCHS=amd64
     ;;
   8 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.24_p8
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:8.402.06-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:8.422.05-jre
     ;;
   11 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.24_p8
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:11.0.24_p8-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9-jre
     ;;
   17 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.4_p7
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:17.0.12_p7-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.5_p11
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:17.0.13_p11-jre
     ;;
   21 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.4_p7
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:21.0.4_p7-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.5_p11
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:21.0.5_p11-jre
     ;;
   * )
     echo "Invalid JRE_VERSION: ${JRE_VERSION}"

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -58,7 +58,7 @@ fi
 
 if ! test -f ${artifact_id}.jar && [ ${is_release} = "true" ]; then
   mvn_get="mvn -q --batch-mode -Denforcer.fail=false \
-  org.apache.maven.plugins:maven-dependency-plugin:3.7.1:get \
+  org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
   -Dtransitive=false -DgroupId=${group_id} -DartifactId=${artifact_id} -Dversion=${version}"
 
   if [ -n "${classifier}" ]; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,9 @@
 # non-root users and such as they are not intended to run in production anyway.
 
 # The image binaries this example builds are installed over
-ARG docker_parent_image=ghcr.io/openzipkin/java:21.0.4_p7
+ARG docker_parent_image=ghcr.io/openzipkin/java:21.0.5_p11
 ## Use JDK 11 to build projects, as that can still compile Java 6
-ARG docker_build_image=ghcr.io/openzipkin/java:11.0.24_p8
+ARG docker_build_image=ghcr.io/openzipkin/java:11.0.25_p9
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -45,8 +45,8 @@
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
-    <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
-    <maven-help-plugin.version>3.4.1</maven-help-plugin.version>
+    <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
+    <maven-help-plugin.version>3.5.1</maven-help-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
   </properties>


### PR DESCRIPTION
assuming this works, the same version updates should happen on zipkin and associated downstream builds like otel.

If a downstream build is dependent on zipkin, of course that should be bumped and released first.

Note: I only updated the versions cached or aligned with the docker images. Other maven versions may need to be bumped.