### PR TITLE
Updates docker images to latest Java on Alpine 3.21.2

### DIFF
--- a/build-bin/docker-compose.base.yml
+++ b/build-bin/docker-compose.base.yml
@@ -7,7 +7,7 @@ version: "2.4"
 services:
   sut:
     container_name: sut
-    image: ghcr.io/openzipkin/alpine:3.20.3
+    image: ghcr.io/openzipkin/alpine:3.21.2
     entrypoint: /bin/sh
     # Keep the container running until HEALTHCHECK passes
     command: "-c \"sleep 5m\""
@@ -16,7 +16,7 @@ services:
       test: wget -qO- --spider http://zipkin:9411/api/v2/trace/cafebabecafebabe
   get_frontend:
     container_name: get_frontend
-    image: ghcr.io/openzipkin/alpine:3.20.3
+    image: ghcr.io/openzipkin/alpine:3.21.2
     entrypoint: /bin/sh
     # Pass a trace header with a constant trace ID, so that we know what to look for later
     command: "-c \"wget -qO- --header 'b3: cafebabecafebabe-cafebabecafebabe-1' http://frontend:8081\""

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -37,7 +37,7 @@ if [ -n "${DOCKER_TARGET}" ]; then
 fi
 
 # When non-empty, becomes the layer that builds the maven projects.
-# e.g. ghcr.io/openzipkin/java:11.0.25_p9
+# e.g. ghcr.io/openzipkin/java:11.0.26_p4
 #
 # This must include maven and a full JDK.
 if [ -n "${DOCKER_BUILD_IMAGE}" ]; then
@@ -45,9 +45,9 @@ if [ -n "${DOCKER_BUILD_IMAGE}" ]; then
 fi
 
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
-# e.g. ghcr.io/openzipkin/java:21.0.5_p11-jre
+# e.g. ghcr.io/openzipkin/java:21.0.6_p7-jre
 #
-# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
+# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.21.2
 # See https://docs.docker.com/glossary/#parent-image
 if [ -n "${DOCKER_PARENT_IMAGE}" ]; then
   docker_args="${docker_args} --build-arg docker_parent_image=${DOCKER_PARENT_IMAGE}"
@@ -59,7 +59,7 @@ if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"
 fi
 
-# When non-empty, becomes the build-arg java_version. e.g. "21.0.5_p11"
+# When non-empty, becomes the build-arg java_version. e.g. "21.0.6_p7"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/java
 if [ -n "${JAVA_VERSION}" ]; then
   docker_args="${docker_args} --build-arg java_version=${JAVA_VERSION}"

--- a/build-bin/docker_args
+++ b/build-bin/docker_args
@@ -8,38 +8,38 @@ else
   exit 1
 fi
 
-JAVA_VERSION=${JAVA_VERSION:-21.0.5_p11}
+JAVA_VERSION=${JAVA_VERSION:-21.0.6_p7}
 # DOCKER_ARCHS to eventually push to the registry
 DOCKER_ARCHS="amd64 arm64"
 
 case "${JRE_VERSION}" in
   6 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.26_p4
     DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:1.6.0-119
     # single arch image
     DOCKER_ARCHS=amd64
     ;;
   7 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.26_p4
     DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:1.7.0_352
     # single arch image
     DOCKER_ARCHS=amd64
     ;;
   8 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.26_p4
     DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:8.422.05-jre
     ;;
   11 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:11.0.25_p9-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:11.0.26_p4
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:11.0.26_p4-jre
     ;;
   17 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.5_p11
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:17.0.13_p11-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.6_p7
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:17.0.9_p8-jre
     ;;
   21 )
-    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.5_p11
-    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:21.0.5_p11-jre
+    DOCKER_BUILD_IMAGE=ghcr.io/openzipkin/java:21.0.6_p7
+    DOCKER_PARENT_IMAGE=ghcr.io/openzipkin/java:21.0.6_p7-jre
     ;;
   * )
     echo "Invalid JRE_VERSION: ${JRE_VERSION}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,9 @@
 # non-root users and such as they are not intended to run in production anyway.
 
 # The image binaries this example builds are installed over
-ARG docker_parent_image=ghcr.io/openzipkin/java:21.0.5_p11
+ARG docker_parent_image=ghcr.io/openzipkin/java:21.0.6_p7
 ## Use JDK 11 to build projects, as that can still compile Java 6
-ARG docker_build_image=ghcr.io/openzipkin/java:11.0.25_p9
+ARG docker_build_image=ghcr.io/openzipkin/java:11.0.26_p4
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.


### PR DESCRIPTION
all java is updated except 8, which is stuck still per https://gitlab.alpinelinux.org/alpine/aports/-/issues/16625